### PR TITLE
fix(cli): make daemon command load bundled daemon module

### DIFF
--- a/packages/cli/src/daemon-manager.ts
+++ b/packages/cli/src/daemon-manager.ts
@@ -9,18 +9,26 @@ import { dirname, resolve } from "node:path";
 import { DAEMON_BASE_URL } from "@bb-browser/shared";
 
 /** 获取 daemon dist 路径 */
-function getDaemonPath(): string {
+export function getDaemonPath(): string {
   const currentFile = fileURLToPath(import.meta.url);
   const currentDir = dirname(currentFile);
-  
-  // npm 发布后：cli.js 和 daemon.js 在同一目录 (dist/)
+
   const sameDirPath = resolve(currentDir, "daemon.js");
+  const workspacePath = resolve(currentDir, "../../daemon/dist/index.js");
+
+  // npm 发布后：cli.js 和 daemon.js 在同一目录 (dist/)
   if (existsSync(sameDirPath)) {
     return sameDirPath;
   }
-  
+
   // 开发模式：CLI dist 在 packages/cli/dist/，Daemon dist 在 packages/daemon/dist/
-  return resolve(currentDir, "../../daemon/dist/index.js");
+  if (existsSync(workspacePath)) {
+    return workspacePath;
+  }
+
+  throw new Error(
+    `找不到 Daemon 入口文件。已尝试:\n- ${sameDirPath}\n- ${workspacePath}`
+  );
 }
 
 /** Daemon 启动超时时间（毫秒） */


### PR DESCRIPTION
Fixes #6

## Problem
The CLI's daemon command relied on workspace package paths (@bb-browser/daemon), which are not resolvable in the npm distribution format.

## Solution
Modified the daemon loading logic to support both workspace and bundled distribution paths.

## Changes
- Updated `packages/cli/src/commands/daemon.ts` to handle loading from bundled distribution.
- Updated `packages/cli/src/daemon-manager.ts` for better daemon management.
- Refactored `packages/daemon/src/index.ts` to export `startDaemon` for programmatic use.