### PR TITLE
fix: bypass CSP and fix cross-origin fetch for site adapters

### DIFF
--- a/packages/cli/src/commands/site.ts
+++ b/packages/cli/src/commands/site.ts
@@ -334,8 +334,35 @@ async function siteRun(
   const jsBody = jsContent.replace(/\/\*\s*@meta[\s\S]*?\*\//, "").trim();
 
   // 构造执行脚本
+  // Wrap adapter execution with a fetch() override that drops credentials
+  // for cross-origin requests. Browsers block cross-origin fetch with
+  // credentials: 'include' unless the server explicitly allows it via
+  // Access-Control-Allow-Credentials. Most site adapters set credentials
+  // for same-origin cookie auth, but this breaks when they also make
+  // cross-origin API calls. The wrapper detects cross-origin requests
+  // and downgrades them to credentials: 'omit'.
   const argsJson = JSON.stringify(argMap);
-  const script = `(${jsBody})(${argsJson})`;
+  const script = `(async () => {
+    const __origFetch = window.fetch.bind(window);
+    const __pageOrigin = location.origin;
+    window.fetch = function(input, init) {
+      try {
+        const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+        if (url.startsWith('http') && !url.startsWith(__pageOrigin)) {
+          init = Object.assign({}, init || {});
+          if (init.credentials === 'include') {
+            init.credentials = 'omit';
+          }
+        }
+      } catch(e) {}
+      return __origFetch(input, init);
+    };
+    try {
+      return await (${jsBody})(${argsJson});
+    } finally {
+      window.fetch = __origFetch;
+    }
+  })()`;
 
   await ensureDaemonRunning();
 

--- a/packages/extension/src/background/cdp-service.ts
+++ b/packages/extension/src/background/cdp-service.ts
@@ -223,10 +223,14 @@ export async function ensureAttached(tabId: number): Promise<void> {
     
     // 启用必要的 CDP 域
     await chrome.debugger.sendCommand({ tabId }, 'Page.enable');
+    // Bypass CSP so that site adapters can make cross-origin fetch() calls
+    // that would otherwise be blocked by connect-src directives.
+    // This only takes effect for page loads that occur after this command.
+    await chrome.debugger.sendCommand({ tabId }, 'Page.setBypassCSP', { enabled: true });
     await chrome.debugger.sendCommand({ tabId }, 'DOM.enable');
     await chrome.debugger.sendCommand({ tabId }, 'Runtime.enable');
     
-    console.log('[CDPService] Attached to tab:', tabId);
+    console.log('[CDPService] Attached to tab (CSP bypassed):', tabId);
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     // 如果已经 attached，忽略错误


### PR DESCRIPTION
## Problem

~50% of site adapters fail with `TypeError: Failed to fetch` when running cross-origin API calls via `bb-browser site`. Two separate browser security mechanisms cause this:

1. **CSP connect-src**: Sites like HackerNews, npm, and StackOverflow set Content-Security-Policy headers that restrict which domains `fetch()` can reach. Adapter eval scripts inherit these restrictions.

2. **CORS + credentials**: Many adapters use `credentials: 'include'` for same-origin cookie auth, but this triggers CORS preflight for cross-origin requests. Most API servers don't set `Access-Control-Allow-Credentials`, causing the browser to reject the response.

### Affected adapters (tested)
| Adapter | Root cause | After fix |
|---------|-----------|-----------|
| hackernews/top | CSP blocks `firebaseio.com` | ✅ |
| npm/search | CSP blocks `registry.npmjs.org` | ✅ |
| stackoverflow/search | CSP + CORS | ✅ |
| github/me | Adapter bug (needs OAuth, not cookies) | ❌ separate issue |
| twitter/* | Needs login (expected) | N/A |

## Solution

### 1. Extension: `Page.setBypassCSP` (cdp-service.ts)

Call `Page.setBypassCSP({ enabled: true })` immediately after attaching the debugger to a tab. This disables CSP enforcement for pages loaded while the debugger is attached.

**Note:** This only affects pages loaded *after* the command. Tabs already open need a refresh. New tabs created by `bb-browser` work automatically since the debugger attaches before navigation.

### 2. CLI: Cross-origin fetch wrapper (site.ts)

Wrap adapter execution with a `fetch()` interceptor that detects cross-origin requests and downgrades `credentials: 'include'` to `credentials: 'omit'`. Same-origin requests are unaffected, preserving cookie-based auth.

## Testing

Tested on macOS with Chrome 146 + bb-browser 0.3.0:

```
bb-browser site hackernews/top 5      # ✅ was: Failed to fetch
bb-browser site npm/search react       # ✅ was: Failed to fetch  
bb-browser site stackoverflow/search async  # ✅ was: Failed to fetch
bb-browser site reddit/posts spez      # ✅ unaffected (same-origin)
bb-browser site duckduckgo/search test # ✅ unaffected (same-origin)
```