### PR TITLE
feat: Add `open` CLI command and define its shared protocol.

### DIFF
--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -45,14 +45,14 @@ export async function openCommand(
   if (options.tab !== undefined) {
     if (options.tab === "current") {
       // 使用当前活动 tab
-      (request as Record<string, unknown>).tabId = "current";
+      request.tabId = "current";
     } else {
       // 使用指定 tabId
       const tabId = parseInt(options.tab, 10);
       if (isNaN(tabId)) {
         throw new Error(`无效的 tabId: ${options.tab}`);
       }
-      (request as Record<string, unknown>).tabId = tabId;
+      request.tabId = tabId;
     }
   }
   // 不指定 --tab 时，tabId 为 undefined，扩展会创建新 tab

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -280,6 +280,14 @@ export interface ResponseData {
   traceEvents?: TraceEvent[];
   /** Trace 录制状态（trace status 命令返回） */
   traceStatus?: TraceStatus;
+  /** 元素角色（check/uncheck 命令返回） */
+  role?: string;
+  /** 元素名称（check/uncheck 命令返回） */
+  name?: string;
+  /** 是否之前已勾选（check 命令返回） */
+  wasAlreadyChecked?: boolean;
+  /** 是否之前已取消勾选（uncheck 命令返回） */
+  wasAlreadyUnchecked?: boolean;
 }
 
 /** 响应类型 */


### PR DESCRIPTION
The

Request
 interface in

protocol.ts
 already has tabId?: number | string (line 67), so the as Record<string, unknown> casts on lines 48 and 55 were unnecessary. TypeScript was rightfully flagging this — it's saying "you're casting

Request
 to Record<string, unknown>, but

Request
 doesn't have an index signature, so these types aren't compatible."

The fix: Simply use request.tabId = ... directly, since tabId is already a declared property on

Request
. No casting needed at all. ✅