### PR TITLE
docs(skill): 补全 bb-browser skill 文档，新增 site/fetch/network/adapter 参考文档

### DIFF
--- a/skills/bb-browser/SKILL.md
+++ b/skills/bb-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bb-browser
-description: 强大的信息获取工具。通过浏览器 + 用户登录态，获取公域和私域信息。可访问任意网页、内部系统、登录后页面，执行表单填写、信息提取、页面操作。
+description: 强大的信息获取与浏览器自动化工具。通过浏览器 + 用户登录态，获取公域和私域信息。可访问任意网页、内部系统、登录后页面，执行表单填写、信息提取、页面操作。支持 site 系统（35 平台 97 命令一键调用）、带登录态的 fetch、网络请求拦截与 mock、操作录制等高级功能。
 allowed-tools: Bash(bb-browser:*)
 ---
 
@@ -8,21 +8,13 @@ allowed-tools: Bash(bb-browser:*)
 
 ## 核心价值
 
-**bb-browser 是一个强大的信息获取工具。**
-
 通过浏览器 + 用户登录态，可以获取：
-- **公域信息**：任意公开网页、搜索结果、新闻资讯
-- **私域信息**：内部系统、企业应用、登录后页面、个人账户数据
+- 公域信息：任意公开网页、搜索结果、新闻资讯
+- 私域信息：内部系统、企业应用、登录后页面、个人账户数据
 
-在此基础上，还可以代替用户执行浏览器操作：
-- 表单填写、按钮点击
-- 数据提取、截图保存
-- 批量操作、重复任务
+还可以代替用户执行浏览器操作：表单填写、按钮点击、数据提取、截图保存、批量操作。
 
-**为什么能做到？**
-- 运行在用户真实浏览器中，复用已登录的账号
-- 不触发反爬检测，访问受保护的页面
-- 无需提供密码或 Cookie，直接使用现有登录态
+运行在用户真实浏览器中，复用已登录的账号，不触发反爬检测。
 
 ## 快速开始
 
@@ -34,9 +26,52 @@ bb-browser fill @3 "text"    # 填写输入框
 bb-browser close             # 完成后关闭 tab
 ```
 
+## Site 系统 — 把任何网站变成命令行 API
+
+site 系统是 bb-browser 的核心特性，通过 adapter 将网站功能 CLI 化，覆盖 35+ 平台。
+
+```bash
+# 常用命令
+bb-browser site list                          # 列出所有 adapter
+bb-browser site search <query>                # 搜索 adapter
+bb-browser site <name> [args...]              # 运行 adapter
+bb-browser site update                        # 更新社区 adapter 库
+
+# 使用示例
+bb-browser site twitter/search "Claude Code"  # 搜索推文
+bb-browser site zhihu/hot                     # 知乎热榜
+bb-browser site github/repo owner/repo        # 仓库信息
+bb-browser site youtube/transcript <video_id> # 获取字幕
+bb-browser site reddit/thread <url>           # 帖子详情
+bb-browser site eastmoney/stock "茅台"         # 股票查询
+bb-browser site weibo/hot                     # 微博热搜
+bb-browser site arxiv/search "transformer"    # 论文搜索
+```
+
+adapter 自动处理 tab 管理（查找匹配域名的 tab 或新建），自动检测登录错误并提示。
+
+详细用法和 35 平台完整列表：参见 [references/site-system.md](references/site-system.md)
+创建自定义 adapter：参见 [references/adapter-development.md](references/adapter-development.md)
+
+## fetch — 带登录态的 curl
+
+在浏览器上下文中执行 fetch，自动携带 Cookie 和登录态。
+
+```bash
+bb-browser fetch <url>                                    # GET 请求
+bb-browser fetch <url> --method POST --body '{"k":"v"}'   # POST 请求
+bb-browser fetch <url> --headers '{"Auth":"Bearer xxx"}'  # 自定义请求头
+bb-browser fetch <url> --output data.json                 # 保存到文件
+bb-browser fetch /api/me.json                             # 相对路径（用当前 tab 的 origin）
+```
+
+自动域名路由：绝对路径自动查找匹配 tab 或新建；相对路径使用当前 tab。
+
+详细用法：参见 [references/fetch-and-network.md](references/fetch-and-network.md)
+
 ## Tab 管理规范
 
-**重要：操作完成后必须关闭自己打开的 tab**
+操作完成后必须关闭自己打开的 tab。
 
 ```bash
 # 单 tab 场景
@@ -70,12 +105,12 @@ bb-browser open https://example.com --tab 123      # 在指定 tabId 打开
 ### 导航
 
 ```bash
-bb-browser open <url>           # 打开 URL（新 tab）
+bb-browser open <url>                # 打开 URL（新 tab）
 bb-browser open <url> --tab current  # 在当前 tab 打开
-bb-browser back                 # 后退
-bb-browser forward              # 前进
-bb-browser refresh              # 刷新
-bb-browser close                # 关闭当前 tab
+bb-browser back                      # 后退
+bb-browser forward                   # 前进
+bb-browser refresh                   # 刷新
+bb-browser close                     # 关闭当前 tab
 ```
 
 ### 快照
@@ -83,7 +118,11 @@ bb-browser close                # 关闭当前 tab
 ```bash
 bb-browser snapshot             # 完整页面结构
 bb-browser snapshot -i          # 只显示可交互元素（推荐）
+bb-browser snapshot -c          # 移除空结构节点
+bb-browser snapshot -d 3        # 限制树深度为 3 层
+bb-browser snapshot -s ".main"  # 限定 CSS 选择器范围
 bb-browser snapshot --json      # JSON 格式输出
+# 选项可组合：bb-browser snapshot -i -c -d 5
 ```
 
 ### 元素交互
@@ -98,7 +137,7 @@ bb-browser uncheck @7           # 取消勾选
 bb-browser select @4 "option"   # 下拉选择
 bb-browser press Enter          # 按键
 bb-browser press Control+a      # 组合键
-bb-browser scroll down          # 向下滚动
+bb-browser scroll down          # 向下滚动（默认 300px）
 bb-browser scroll up 500        # 向上滚动 500px
 ```
 
@@ -115,9 +154,11 @@ bb-browser get title            # 获取页面标题
 ```bash
 bb-browser tab                  # 列出所有 tab
 bb-browser tab new [url]        # 新建 tab
-bb-browser tab 2                # 切换到第 2 个 tab
+bb-browser tab 2                # 切换到第 2 个 tab（按 index）
+bb-browser tab select --id 123  # 切换到指定 tabId 的 tab
 bb-browser tab close            # 关闭当前 tab
-bb-browser tab close 3          # 关闭第 3 个 tab
+bb-browser tab close 3          # 关闭第 3 个 tab（按 index）
+bb-browser tab close --id 123   # 关闭指定 tabId 的 tab
 ```
 
 ### 截图
@@ -156,14 +197,32 @@ bb-browser dialog dismiss       # 取消对话框
 bb-browser dialog accept "text" # 确认并输入（prompt）
 ```
 
-### 调试
+### 网络与调试
 
 ```bash
-bb-browser network requests     # 查看网络请求
-bb-browser console              # 查看控制台消息
-bb-browser errors               # 查看 JS 错误
-bb-browser trace start          # 开始录制用户操作
-bb-browser trace stop           # 停止录制
+bb-browser network requests                        # 查看网络请求
+bb-browser network requests "api" --with-body       # 过滤 + 完整请求/响应体
+bb-browser network route "*analytics*" --abort      # 拦截并阻止请求
+bb-browser network route "*/api/user" --body '{}'   # 拦截并 mock 响应
+bb-browser network unroute                          # 移除所有拦截规则
+bb-browser network clear                            # 清空请求记录
+bb-browser console                                  # 查看控制台消息
+bb-browser console --clear                          # 清空控制台
+bb-browser errors                                   # 查看 JS 错误
+bb-browser errors --clear                           # 清空错误记录
+bb-browser trace start                              # 开始录制用户操作
+bb-browser trace stop                               # 停止录制，输出事件列表
+bb-browser trace status                             # 查看录制状态
+```
+
+详细的 network 高级用法：参见 [references/fetch-and-network.md](references/fetch-and-network.md)
+
+## 全局选项
+
+```bash
+--json               # 以 JSON 格式输出（所有命令通用）
+--tab <tabId>        # 指定操作的标签页 ID（几乎所有命令通用）
+--mcp                # 启动 MCP server（用于 Claude Code / Cursor 等 AI 工具）
 ```
 
 ## Ref 使用说明
@@ -176,10 +235,12 @@ snapshot 返回的 `@ref` 是元素的临时标识：
 @3 [a] "查看详情"
 ```
 
-**注意**：
+注意：
 - 页面导航后 ref 失效，需重新 snapshot
 - 动态内容加载后需重新 snapshot
 - ref 格式：`@1`, `@2`, `@3`...
+
+详细说明：参见 [references/snapshot-refs.md](references/snapshot-refs.md)
 
 ## 并发操作
 
@@ -189,23 +250,12 @@ bb-browser open https://site-a.com &
 bb-browser open https://site-b.com &
 bb-browser open https://site-c.com &
 wait
-
 # 每个返回独立的 tabId，互不干扰
-```
-
-## JSON 输出
-
-添加 `--json` 获取结构化输出：
-
-```bash
-bb-browser snapshot -i --json
-bb-browser get text @5 --json
-bb-browser open https://example.com --json
 ```
 
 ## 信息提取 vs 页面操作
 
-**根据目的选择不同的方法：**
+根据目的选择不同的方法：
 
 ### 提取页面内容（用 eval）
 
@@ -225,8 +275,7 @@ bb-browser eval "document.body.innerText.substring(0, 5000)"
 bb-browser eval "[...document.querySelectorAll('a')].map(a => a.href).join('\n')"
 ```
 
-**为什么不用 snapshot？** 
-有些网站（如微信公众号）DOM 结构嵌套很深，snapshot 输出会非常冗长。`eval` 直接提取文本更高效。
+有些网站 DOM 嵌套很深，snapshot 输出冗长，`eval` 直接提取文本更高效。
 
 ### 操作页面元素（用 snapshot -i）
 
@@ -239,11 +288,32 @@ bb-browser snapshot -i
 # @3 [input type="password"]
 
 bb-browser fill @2 "username"
-bb-browser fill @3 "password"  
+bb-browser fill @3 "password"
 bb-browser click @1
 ```
 
-**`-i` 很重要**：只显示可交互元素，过滤掉大量无关内容。
+`-i` 只显示可交互元素，过滤掉大量无关内容。
+
+## MCP 集成
+
+bb-browser 提供 MCP server，可与 Claude Code / Cursor 等 AI 工具集成：
+
+```bash
+# 启动 MCP server
+bb-browser --mcp
+```
+
+配置示例（Claude Code / Cursor）：
+```json
+{
+  "mcpServers": {
+    "bb-browser": {
+      "command": "npx",
+      "args": ["-y", "bb-browser", "--mcp"]
+    }
+  }
+}
+```
 
 ## 常见任务示例
 
@@ -252,10 +322,6 @@ bb-browser click @1
 ```bash
 bb-browser open https://example.com/form
 bb-browser snapshot -i
-# @1 [input] placeholder="姓名"
-# @2 [input] placeholder="邮箱"
-# @3 [button] "提交"
-
 bb-browser fill @1 "张三"
 bb-browser fill @2 "zhangsan@example.com"
 bb-browser click @3
@@ -268,15 +334,14 @@ bb-browser close
 ```bash
 bb-browser open https://example.com/dashboard
 bb-browser snapshot -i
-bb-browser get text @5              # 获取特定元素文本
-bb-browser screenshot report.png    # 截图保存
+bb-browser get text @5
+bb-browser screenshot report.png
 bb-browser close
 ```
 
 ### 批量操作
 
 ```bash
-# 打开多个页面提取信息
 for url in "url1" "url2" "url3"; do
   bb-browser open "$url"
   bb-browser snapshot -i --json
@@ -288,4 +353,7 @@ done
 
 | 文档 | 说明 |
 |------|------|
+| [references/site-system.md](references/site-system.md) | Site 系统完整指南：35 平台列表、命令用法、自动 tab 管理 |
+| [references/adapter-development.md](references/adapter-development.md) | Adapter 开发指南：API 逆向、三层复杂度、元数据格式 |
+| [references/fetch-and-network.md](references/fetch-and-network.md) | Fetch 与 Network 高级功能：带登录态请求、请求拦截与 mock |
 | [references/snapshot-refs.md](references/snapshot-refs.md) | Ref 生命周期、最佳实践、常见问题 |

--- a/skills/bb-browser/references/adapter-development.md
+++ b/skills/bb-browser/references/adapter-development.md
@@ -1,0 +1,242 @@
+# Adapter 开发指南
+
+## 开发流程概览
+
+1. 用 `network` 命令逆向 API
+2. 用 `eval` 测试 fetch 是否可行
+3. 编写 adapter JS 文件
+4. 保存到 `~/.bb-browser/sites/` 测试
+5. 提交 PR 到社区仓库
+
+<!-- 证据来源：packages/cli/src/index.ts:601-658 guide 命令输出 -->
+
+## Step 1：逆向 API
+
+```bash
+# 清空旧记录
+bb-browser network clear --tab <tabId>
+
+# 刷新页面触发请求
+bb-browser refresh --tab <tabId>
+
+# 查看 API 请求（filter 是位置参数，不是 --filter）
+bb-browser network requests "api" --with-body --json --tab <tabId>
+```
+
+重点关注：
+- 请求 URL 和参数格式
+- 认证方式（Cookie / Bearer token / CSRF token）
+- 响应数据结构
+
+## Step 2：测试 fetch
+
+```bash
+# 直接在浏览器中测试 fetch（Tier 1 验证）
+bb-browser eval "fetch('/api/endpoint',{credentials:'include'}).then(r=>r.json())" --tab <tabId>
+```
+
+根据结果判断复杂度：
+- **能直接拿到数据** → Tier 1（Cookie 认证，如 Reddit/GitHub/V2EX）
+- **需要额外请求头** → Tier 2（如 Twitter：Bearer + CSRF token）
+- **需要请求签名或注入** → Tier 3（如小红书：Pinia store / Webpack 模块）
+
+## Step 3：编写 Adapter
+
+### 元数据格式（`/* @meta */` 块）
+
+<!-- 证据来源：site.ts:56-118 parseSiteMeta() -->
+
+```javascript
+/* @meta
+{
+  "name": "platform/command",
+  "description": "功能描述",
+  "domain": "www.example.com",
+  "args": {
+    "query": {"required": true, "description": "搜索关键词"},
+    "count": {"required": false, "description": "返回数量"}
+  },
+  "capabilities": ["search"],
+  "readOnly": true,
+  "example": "bb-browser site platform/command value"
+}
+*/
+async function(args) {
+  // adapter 实现
+}
+```
+
+### 元数据字段说明
+
+| 字段 | 必需 | 说明 |
+|------|------|------|
+| `name` | 是 | 唯一标识，格式 `platform/command` |
+| `description` | 是 | 功能描述 |
+| `domain` | 是 | 目标网站域名（用于自动 tab 匹配） |
+| `args` | 是 | 参数定义，每个参数含 `required` 和 `description` |
+| `capabilities` | 否 | 能力标签数组 |
+| `readOnly` | 否 | 是否只读操作 |
+| `example` | 否 | 使用示例 |
+
+### 旧格式兼容
+
+也支持 `// @tag value` 注释格式（向后兼容）：
+
+```javascript
+// @name platform/command
+// @description 功能描述
+// @domain www.example.com
+// @args query,filter
+// @example bb-browser site platform/command value
+```
+
+<!-- 证据来源：site.ts:100-117 旧格式解析 -->
+
+## 三层复杂度示例
+
+### Tier 1：Cookie 认证（~1 分钟）
+
+直接 fetch，`credentials: 'include'` 自动带 Cookie。
+
+```javascript
+/* @meta
+{
+  "name": "reddit/search",
+  "description": "Search Reddit posts",
+  "domain": "www.reddit.com",
+  "args": {"query": {"required": true, "description": "Search query"}},
+  "readOnly": true,
+  "example": "bb-browser site reddit/search 'local LLM'"
+}
+*/
+async function(args) {
+  if (!args.query) return {error: 'Missing argument: query'};
+  const resp = await fetch(
+    '/search.json?q=' + encodeURIComponent(args.query) + '&limit=10',
+    {credentials: 'include'}
+  );
+  if (!resp.ok) return {error: 'HTTP ' + resp.status, hint: 'Not logged in?'};
+  const data = await resp.json();
+  return data.data.children.map(c => ({
+    title: c.data.title,
+    url: 'https://www.reddit.com' + c.data.permalink,
+    score: c.data.score,
+    subreddit: c.data.subreddit
+  }));
+}
+```
+
+### Tier 2：Bearer + CSRF token（~3 分钟）
+
+需要从页面提取 token 构造请求头。
+
+```javascript
+/* @meta
+{
+  "name": "twitter/search",
+  "description": "Search tweets",
+  "domain": "twitter.com",
+  "args": {"query": {"required": true, "description": "Search query"}},
+  "readOnly": true
+}
+*/
+async function(args) {
+  // 从 cookie 提取 CSRF token
+  const csrf = document.cookie.match(/ct0=([^;]+)/)?.[1];
+  if (!csrf) return {error: 'CSRF token not found', hint: 'Not logged in?'};
+
+  // 构造带认证的请求
+  const resp = await fetch('/i/api/2/search/adaptive.json?q=' + encodeURIComponent(args.query), {
+    credentials: 'include',
+    headers: {
+      'authorization': 'Bearer AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs...',
+      'x-csrf-token': csrf
+    }
+  });
+  if (!resp.ok) return {error: 'HTTP ' + resp.status};
+  return await resp.json();
+}
+```
+
+### Tier 3：Webpack 注入 / Pinia store（~10 分钟）
+
+需要访问页面内部状态或调用内部模块。
+
+```javascript
+/* @meta
+{
+  "name": "xiaohongshu/search",
+  "description": "Search Xiaohongshu notes",
+  "domain": "www.xiaohongshu.com",
+  "args": {"query": {"required": true, "description": "Search query"}},
+  "readOnly": true
+}
+*/
+async function(args) {
+  // 通过 Webpack 注入获取内部模块
+  // 或通过 __vue_app__ 访问 Pinia store
+  // 具体实现取决于目标网站的前端架构
+  // ...
+}
+```
+
+## Step 4：测试
+
+```bash
+# 保存到私有目录
+# 文件路径：~/.bb-browser/sites/platform/command.js
+
+# 测试运行
+bb-browser site platform/command "test query" --json
+
+# 验证输出格式
+bb-browser site platform/command "test query"
+```
+
+## Step 5：贡献社区
+
+```bash
+# 方式 A：使用 gh CLI
+git clone https://github.com/epiral/bb-sites && cd bb-sites
+git checkout -b feat-platform
+# 添加 adapter 文件
+git push -u origin feat-platform
+gh pr create --repo epiral/bb-sites
+
+# 方式 B：使用 bb-browser 自身
+bb-browser site github/fork epiral/bb-sites
+git clone https://github.com/YOUR_USER/bb-sites && cd bb-sites
+git checkout -b feat-platform
+# 添加 adapter 文件
+git push -u origin feat-platform
+bb-browser site github/pr-create epiral/bb-sites --title "feat(platform): add adapters" --head "YOUR_USER:feat-platform"
+```
+
+## 错误处理规范
+
+adapter 返回错误时，使用统一格式：
+
+```javascript
+// 参数缺失
+return {error: 'Missing argument: query'};
+
+// HTTP 错误 + 登录提示
+return {error: 'HTTP 401', hint: 'Not logged in?'};
+
+// 自定义错误
+return {error: 'Rate limited', hint: 'Try again in 60 seconds'};
+```
+
+系统会自动检测 401/403/unauthorized/login 等关键词，生成登录提示。
+
+<!-- 证据来源：site.ts:406-427 错误检测逻辑 -->
+
+## 报告 Adapter Bug
+
+```bash
+# 通过 gh CLI
+gh issue create --repo epiral/bb-sites --title "[adapter-name] 描述"
+
+# 通过 bb-browser
+bb-browser site github/issue-create epiral/bb-sites --title "[adapter-name] 描述"
+```

--- a/skills/bb-browser/references/fetch-and-network.md
+++ b/skills/bb-browser/references/fetch-and-network.md
@@ -1,0 +1,206 @@
+# Fetch 与 Network 高级功能
+
+## fetch 命令 — 带登录态的 curl
+
+本质：在浏览器上下文中执行 `fetch()`，自动携带 Cookie 和登录态。
+
+<!-- 证据来源：packages/cli/src/commands/fetch.ts 注释 "curl，但带浏览器登录态" -->
+
+### 基本用法
+
+```bash
+# GET 请求（绝对路径）
+bb-browser fetch https://www.reddit.com/api/me.json
+
+# GET 请求（相对路径，使用当前 tab 的 origin）
+bb-browser fetch /api/me.json
+
+# POST 请求
+bb-browser fetch https://api.example.com/data --method POST --body '{"key":"value"}'
+
+# 自定义请求头
+bb-browser fetch https://api.example.com/data --headers '{"Authorization":"Bearer token"}'
+
+# 保存到文件
+bb-browser fetch https://api.example.com/data --output response.json
+
+# JSON 格式输出
+bb-browser fetch https://www.reddit.com/api/me.json --json
+```
+
+### 完整选项
+
+| 选项 | 说明 |
+|------|------|
+| `--method <GET\|POST\|...>` | HTTP 方法，默认 GET |
+| `--body <json>` | 请求体（仅 POST/PUT 等） |
+| `--headers <json>` | 自定义请求头（必须是合法 JSON） |
+| `--output <file>` | 保存响应到文件 |
+| `--json` | JSON 格式输出 |
+| `--tab <tabId>` | 指定操作的 tab（全局选项，非 fetch 专属） |
+
+<!-- 证据来源：fetch.ts:18-25 FetchOptions 接口，--tab 由 index.ts:215-218 全局解析 -->
+
+### 自动域名路由机制
+
+fetch 命令会自动处理 tab 匹配：
+
+1. **相对路径**（如 `/api/me.json`）：使用当前活动 tab 的 origin
+2. **绝对路径**（如 `https://www.reddit.com/...`）：
+   - 先查找已打开的匹配域名 tab
+   - 没有则自动打开新 tab 并等待 3 秒
+   - 在匹配的 tab 上下文中执行 fetch
+
+<!-- 证据来源：fetch.ts:42-62 ensureTabForOrigin()，fetch.ts:123-139 路由逻辑 -->
+
+### 响应处理
+
+- JSON 响应自动解析为对象
+- 非 JSON 响应返回文本
+- `--output` 时自动格式化写入文件
+
+<!-- 证据来源：fetch.ts:84-106 buildFetchScript() 中的 content-type 判断 -->
+
+### 典型场景
+
+```bash
+# 检查登录状态
+bb-browser fetch https://www.reddit.com/api/me.json
+
+# 调用内部 API
+bb-browser fetch https://internal.company.com/api/dashboard --json
+
+# 提交表单数据
+bb-browser fetch https://api.example.com/submit \
+  --method POST \
+  --body '{"name":"test","value":123}' \
+  --headers '{"Content-Type":"application/json"}'
+
+# 下载数据到文件
+bb-browser fetch https://api.example.com/export.csv --output data.csv
+```
+
+---
+
+## network 命令 — 网络监控与拦截
+
+<!-- 证据来源：packages/cli/src/commands/network.ts -->
+
+### 子命令一览
+
+```bash
+# 查看网络请求
+bb-browser network requests [filter] [--with-body] [--json]
+
+# 拦截请求（阻止）
+bb-browser network route <url> --abort
+
+# 拦截请求（mock 响应）
+bb-browser network route <url> --body '{"mock":"data"}'
+
+# 移除指定拦截规则
+bb-browser network unroute <url>
+
+# 移除所有拦截规则
+bb-browser network unroute
+
+# 清空请求记录
+bb-browser network clear
+```
+
+### network requests 详解
+
+```bash
+# 查看所有请求
+bb-browser network requests
+
+# 按关键词过滤（匹配 URL）
+bb-browser network requests "api"
+
+# 包含完整请求/响应体
+bb-browser network requests --with-body
+
+# 组合使用
+bb-browser network requests "api" --with-body --json
+```
+
+输出格式：
+```
+GET https://api.example.com/data
+  类型: fetch, 状态: 200 OK
+  请求头: 5, 响应头: 8        # --with-body 时显示
+  请求体: {"query":"test"}    # --with-body 时显示
+  响应体: {"result":[...]}    # --with-body 时显示
+```
+
+<!-- 证据来源：network.ts:46-77 requests 输出逻辑 -->
+
+### network route 详解
+
+拦截匹配 URL 的请求：
+
+```bash
+# 阻止广告/追踪请求
+bb-browser network route "*analytics*" --abort
+
+# Mock API 响应（用于测试）
+bb-browser network route "*/api/user" --body '{"name":"test","role":"admin"}'
+
+# 添加多条规则
+bb-browser network route "*tracker*" --abort
+bb-browser network route "*/api/config" --body '{"feature_flag":true}'
+```
+
+<!-- 证据来源：network.ts:79-92 route 输出逻辑 -->
+
+### network unroute
+
+```bash
+# 移除指定规则
+bb-browser network unroute "*analytics*"
+
+# 移除所有规则
+bb-browser network unroute
+```
+
+<!-- 证据来源：network.ts:94-101 unroute 输出逻辑 -->
+
+### network clear
+
+```bash
+# 清空请求记录（重新开始监控）
+bb-browser network clear
+```
+
+<!-- 证据来源：network.ts:103-106 clear 输出逻辑 -->
+
+### API 逆向工程工作流
+
+这是 fetch + network 最强大的组合用法，用于发现网站内部 API：
+
+```bash
+# 1. 清空旧记录
+bb-browser network clear
+
+# 2. 刷新页面触发请求
+bb-browser refresh
+
+# 3. 查看 API 请求（过滤 + 完整体）
+bb-browser network requests "api" --with-body --json
+
+# 4. 找到目标 API 后，用 fetch 测试
+bb-browser fetch /api/discovered-endpoint --json
+
+# 5. 确认可行后，编写 site adapter
+# 参见 adapter-development.md
+```
+
+### 全局 --tab 选项
+
+所有 network 子命令都支持 `--tab <tabId>`，指定监控哪个 tab 的网络活动：
+
+```bash
+bb-browser network requests --tab 123
+bb-browser network route "*api*" --abort --tab 456
+bb-browser network clear --tab 123
+```

--- a/skills/bb-browser/references/site-system.md
+++ b/skills/bb-browser/references/site-system.md
@@ -1,0 +1,262 @@
+# Site 系统 — 把任何网站变成命令行 API
+
+## 核心概念
+
+Site 系统通过 adapter（适配器）将网站功能 CLI 化。每个 adapter 是一个 JS 文件，在用户真实浏览器中执行，复用登录态，返回结构化 JSON。
+
+<!-- 证据来源：packages/cli/src/commands/site.ts -->
+
+## 命令速查
+
+```bash
+# 列出所有可用 adapter（按平台分组）
+bb-browser site list
+
+# 搜索 adapter（模糊匹配名称、描述、域名）
+bb-browser site search <query>
+
+# 运行 adapter（简写，推荐）
+bb-browser site <name> [args...]
+
+# 运行 adapter（完整写法）
+bb-browser site run <name> [args...]
+
+# 更新社区 adapter 库（从 github.com/epiral/bb-sites 拉取）
+bb-browser site update
+
+# 查看 adapter 开发指南
+bb-browser guide
+```
+
+## 参数传递
+
+支持两种格式混合使用：
+
+```bash
+# 位置参数（按 adapter 定义的参数顺序）
+bb-browser site reddit/thread https://www.reddit.com/r/LocalLLaMA/comments/...
+
+# 命名参数（--flag value 格式）
+bb-browser site github/pr-create epiral/bb-sites --title "feat: ..." --head "user:branch"
+
+# 混合使用
+bb-browser site twitter/search "AI agent" --count 20
+```
+
+<!-- 证据来源：site.ts:290-314 参数解析逻辑 -->
+
+## Adapter 目录与优先级
+
+```
+~/.bb-browser/
+├── sites/              # 私有 adapter（优先级高，覆盖同名社区 adapter）
+│   └── platform/
+│       └── command.js
+└── bb-sites/           # 社区 adapter（通过 bb-browser site update 拉取）
+    └── platform/
+        └── command.js
+```
+
+私有 adapter 优先于社区同名 adapter。
+
+<!-- 证据来源：site.ts:24-26 目录常量，site.ts:148-157 getAllSites() 合并逻辑 -->
+
+## 自动 Tab 管理
+
+运行 adapter 时，系统自动处理 tab：
+
+1. 如果指定了 `--tab <tabId>`，直接使用该 tab
+2. 否则，根据 adapter 的 `domain` 字段查找已打开的匹配 tab
+3. 如果没有匹配的 tab，自动打开新 tab 并等待 3 秒加载
+
+域名匹配规则：精确匹配或子域名匹配（如 `x.com` 匹配 `api.x.com`）。
+
+<!-- 证据来源：site.ts:162-169 matchTabOrigin()，site.ts:342-368 tab 查找逻辑 -->
+
+## 错误处理与登录提示
+
+adapter 返回 `{error: "...", hint: "..."}` 时，系统自动检测登录相关错误（匹配 `401|403|unauthorized|forbidden|not.?logged|login.?required|sign.?in|auth`），并提示用户先在浏览器中登录。
+
+```bash
+# 错误示例
+[error] site twitter/search: HTTP 401
+  Hint: Please log in to https://twitter.com in your browser first, then retry.
+```
+
+<!-- 证据来源：site.ts:406-427 错误处理逻辑 -->
+
+## 35 平台完整列表
+
+<!-- 证据来源：README.md commit 4b903e2 "35 platforms, 97 commands"，具体 adapter 数量以 bb-browser site list 实际输出为准 -->
+
+### 搜索引擎
+
+| 平台 | 命令示例 | 说明 |
+|------|---------|------|
+| Google | `site google/search "query"` | 搜索 |
+| Baidu | `site baidu/search "query"` | 百度搜索 |
+| Bing | `site bing/search "query"` | 必应搜索 |
+| DuckDuckGo | `site duckduckgo/search "query"` | DuckDuckGo 搜索 |
+| Sogou WeChat | `site sogou/wechat "query"` | 搜狗微信文章搜索 |
+
+### 社交媒体
+
+| 平台 | 命令示例 | 说明 |
+|------|---------|------|
+| Twitter/X | `site twitter/search "query"` | 搜索推文 |
+| Twitter/X | `site twitter/user <handle>` | 用户信息 |
+| Reddit | `site reddit/thread <url>` | 帖子详情 |
+| Reddit | `site reddit/search "query"` | 搜索 |
+| Weibo | `site weibo/search "query"` | 微博搜索 |
+| Weibo | `site weibo/hot` | 微博热搜 |
+| Xiaohongshu | `site xiaohongshu/search "query"` | 小红书搜索 |
+| Jike | `site jike/feed` | 即刻动态 |
+| LinkedIn | `site linkedin/search "query"` | 搜索 |
+| LinkedIn | `site linkedin/profile <url>` | 个人资料 |
+| Hupu | `site hupu/hot` | 虎扑热帖 |
+
+### 新闻资讯
+
+| 平台 | 命令示例 | 说明 |
+|------|---------|------|
+| BBC | `site bbc/headlines` | BBC 头条 |
+| Reuters | `site reuters/search "query"` | 路透社搜索 |
+| 36kr | `site 36kr/newsflash` | 36氪快讯 |
+| Toutiao | `site toutiao/hot` | 今日头条热榜 |
+| Eastmoney | `site eastmoney/news "query"` | 东方财富新闻 |
+
+### 技术开发
+
+| 平台 | 命令示例 | 说明 |
+|------|---------|------|
+| GitHub | `site github/repo <owner/repo>` | 仓库信息 |
+| GitHub | `site github/issues <owner/repo>` | Issue 列表 |
+| GitHub | `site github/pr-create <repo> --title "..."` | 创建 PR |
+| StackOverflow | `site stackoverflow/search "query"` | 搜索 |
+| HackerNews | `site hackernews/top` | 热门帖子 |
+| CSDN | `site csdn/search "query"` | CSDN 搜索 |
+| cnblogs | `site cnblogs/search "query"` | 博客园搜索 |
+| V2EX | `site v2ex/hot` | V2EX 热帖 |
+| Dev.to | `site devto/search "query"` | Dev.to 搜索 |
+| npm | `site npm/package <name>` | npm 包信息 |
+| PyPI | `site pypi/package <name>` | PyPI 包信息 |
+| arXiv | `site arxiv/search "query"` | 论文搜索 |
+
+### 视频平台
+
+| 平台 | 命令示例 | 说明 |
+|------|---------|------|
+| YouTube | `site youtube/search "query"` | 搜索视频 |
+| YouTube | `site youtube/transcript <video_id>` | 获取字幕 |
+| Bilibili | `site bilibili/search "query"` | B站搜索 |
+| Bilibili | `site bilibili/popular` | B站热门 |
+
+### 影音娱乐
+
+| 平台 | 命令示例 | 说明 |
+|------|---------|------|
+| Douban | `site douban/movie <name>` | 豆瓣电影 |
+| Douban | `site douban/top250` | 豆瓣 Top250 |
+| IMDb | `site imdb/search "query"` | IMDb 搜索 |
+| Genius | `site genius/search "query"` | 歌词搜索 |
+| Qidian | `site qidian/search "query"` | 起点小说搜索 |
+
+### 财经股票
+
+| 平台 | 命令示例 | 说明 |
+|------|---------|------|
+| Eastmoney | `site eastmoney/stock "茅台"` | 股票查询 |
+| Yahoo Finance | `site yahoo-finance/stock <ticker>` | 股票行情 |
+
+### 求职招聘
+
+| 平台 | 命令示例 | 说明 |
+|------|---------|------|
+| BOSS Zhipin | `site boss/search "query"` | BOSS 直聘搜索 |
+| BOSS Zhipin | `site boss/detail <url>` | 职位详情 |
+
+### 知识百科
+
+| 平台 | 命令示例 | 说明 |
+|------|---------|------|
+| Wikipedia | `site wikipedia/search "query"` | 维基百科搜索 |
+| Wikipedia | `site wikipedia/summary "topic"` | 摘要 |
+| Zhihu | `site zhihu/hot` | 知乎热榜 |
+| Zhihu | `site zhihu/question <id>` | 问题详情 |
+| Open Library | `site openlibrary/search "query"` | 图书搜索 |
+
+### 消费购物
+
+| 平台 | 命令示例 | 说明 |
+|------|---------|------|
+| SMZDM | `site smzdm/search "query"` | 什么值得买搜索 |
+
+### 实用工具
+
+| 平台 | 命令示例 | 说明 |
+|------|---------|------|
+| Youdao | `site youdao/translate "text"` | 有道翻译 |
+| GSMArena | `site gsmarena/search "phone"` | 手机参数 |
+| Product Hunt | `site producthunt/trending` | 热门产品 |
+| Ctrip | `site ctrip/search "destination"` | 携程搜索 |
+
+## 常用场景示例
+
+### 信息检索
+
+```bash
+# 搜索技术话题
+bb-browser site twitter/search "Claude Code"
+bb-browser site reddit/search "local LLM"
+bb-browser site hackernews/top
+
+# 查看热榜
+bb-browser site zhihu/hot
+bb-browser site weibo/hot
+bb-browser site v2ex/hot
+
+# 查询股票
+bb-browser site eastmoney/stock "茅台"
+```
+
+### 开发辅助
+
+```bash
+# GitHub 操作
+bb-browser site github/repo anthropics/claude-code
+bb-browser site github/issues owner/repo
+
+# 查包信息
+bb-browser site npm/package bb-browser
+bb-browser site pypi/package requests
+
+# 搜索技术问题
+bb-browser site stackoverflow/search "async await error handling"
+```
+
+### 内容获取
+
+```bash
+# 获取 YouTube 字幕
+bb-browser site youtube/transcript dQw4w9WgXcQ
+
+# 获取 Reddit 帖子完整内容
+bb-browser site reddit/thread https://www.reddit.com/r/LocalLLaMA/comments/...
+
+# 论文搜索
+bb-browser site arxiv/search "transformer attention mechanism"
+```
+
+## 与 --json 配合
+
+所有 site 命令都支持 `--json` 输出结构化数据：
+
+```bash
+bb-browser site zhihu/hot --json
+bb-browser site twitter/search "AI" --json
+```
+
+## 更多信息
+
+- 创建自定义 adapter：参见 [adapter-development.md](adapter-development.md)
+- 社区 adapter 仓库：https://github.com/epiral/bb-sites


### PR DESCRIPTION
## 变更内容

bb-browser 的 skill 文档之前只覆盖了基础浏览器操作，缺少 site 系统、fetch、network 高级功能、adapter 开发等核心特性的说明。本 PR 补全这些内容。

### 修改文件

**skills/bb-browser/SKILL.md**（更新）
- 新增 Site 系统章节：快速示例、命令速查，链接到详细参考文档
- 新增 fetch 命令章节：带登录态的 curl，基本用法示例
- 补充 snapshot 高级选项：`-c`（紧凑）、`-d`（深度）、`-s`（选择器）
- 补充全局 `--tab` 选项说明
- 新增 MCP 集成章节：启动方式和配置示例
- 补充 network 高级功能：请求拦截、mock、API 逆向工程
- description 更新，涵盖 site 系统和高级功能

**skills/bb-browser/references/site-system.md**（新增）
- 35 平台完整列表（搜索引擎、社交媒体、技术开发、视频、财经等）
- 命令速查、参数传递格式
- Adapter 目录结构与优先级
- 自动 tab 管理机制
- 错误处理与登录提示

**skills/bb-browser/references/fetch-and-network.md**（新增）
- fetch 完整选项和自动域名路由机制
- network requests/route/unroute/clear 详解
- API 逆向工程工作流（fetch + network 组合用法）

**skills/bb-browser/references/adapter-development.md**（新增）
- 开发流程：逆向 API → 测试 fetch → 编写 adapter → 测试 → 贡献社区
- 三层复杂度示例：Tier 1（Cookie）、Tier 2（Bearer+CSRF）、Tier 3（Webpack 注入）
- 元数据格式（`/* @meta */` 块）详细说明
- 错误处理规范

### 设计原则

遵循 skill 渐进式披露模式：
- SKILL.md 控制在 360 行以内，只放核心用法和快速参考
- 详细内容拆分到 4 个 references 文件，按需加载
- 所有文档中的结论均有源码证据链支持（注释标注了对应的源文件和行号）