### PR TITLE
fix: use fileURLToPath for Windows-compatible MCP path resolution

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@
  *   --json                    以 JSON 格式输出
  */
 
+import { fileURLToPath } from "node:url";
 import { openCommand } from "./commands/open.js";
 import { snapshotCommand } from "./commands/snapshot.js";
 import { clickCommand } from "./commands/click.js";
@@ -224,7 +225,7 @@ async function main(): Promise<void> {
   }
 
   if (process.argv.includes("--mcp")) {
-    const mcpPath = new URL("./mcp.js", import.meta.url).pathname;
+    const mcpPath = fileURLToPath(new URL("./mcp.js", import.meta.url));
     const { spawn } = await import("node:child_process");
     const child = spawn(process.execPath, [mcpPath], { stdio: "inherit" });
     child.on("exit", (code) => process.exit(code ?? 0));


### PR DESCRIPTION
## Summary

Fix `--mcp` flag failing on Windows with `MODULE_NOT_FOUND` error due to double drive letter in the resolved path (`C:\C:\...`).

**Root cause:** `new URL("./mcp.js", import.meta.url).pathname` returns a POSIX-style path (`/C:/Users/...`) on Windows, which Node.js then incorrectly resolves to `C:\C:\Users\...`.

**Fix:** Replace `.pathname` with `fileURLToPath()` from `node:url`, which correctly handles `file://` URL-to-path conversion on all platforms.

Fixes #17

## Changes

- Added `import { fileURLToPath } from "node:url"` in `packages/cli/src/index.ts`
- Changed `new URL("./mcp.js", import.meta.url).pathname` to `fileURLToPath(new URL("./mcp.js", import.meta.url))`

## Test

Verified on Windows 10 + Node.js v22.18.0 that `bb-browser --mcp` launches the MCP server correctly after this change.
