### PR TITLE
fix: add Chrome Dev/Canary/Beta/Arc to browser detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-browser",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Your browser is the API. CLI + MCP server for AI agents to control Chrome with your login state.",
   "type": "module",
   "bin": {

--- a/packages/cli/src/cdp-discovery.ts
+++ b/packages/cli/src/cdp-discovery.ts
@@ -56,6 +56,10 @@ export function findBrowserExecutable(): string | null {
   if (process.platform === "darwin") {
     const candidates = [
       "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev",
+      "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+      "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+      "/Applications/Arc.app/Contents/MacOS/Arc",
       "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
       "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
     ];

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,8 +15,6 @@ import { screenshotCommand } from "./commands/screenshot.js";
 import { waitCommand } from "./commands/wait.js";
 import { pressCommand } from "./commands/press.js";
 import { scrollCommand } from "./commands/scroll.js";
-import { statusCommand } from "./commands/daemon.js";
-import { reloadCommand } from "./commands/reload.js";
 import { backCommand, forwardCommand, refreshCommand } from "./commands/nav.js";
 import { checkCommand, uncheckCommand } from "./commands/check.js";
 import { selectCommand } from "./commands/select.js";
@@ -407,27 +405,6 @@ async function main(): Promise<void> {
       }
 
       case "daemon":
-      case "start": {
-        const hostIdx = process.argv.findIndex(a => a === "--host");
-        const host = hostIdx >= 0 ? process.argv[hostIdx + 1] : undefined;
-        await daemonCommand({ json: parsed.flags.json, host });
-        break;
-      }
-
-      case "stop": {
-        await stopCommand({ json: parsed.flags.json });
-        break;
-      }
-
-      case "status": {
-        await statusCommand({ json: parsed.flags.json });
-        break;
-      }
-
-      case "reload": {
-        await reloadCommand({ json: parsed.flags.json });
-        break;
-      }
 
       case "close": {
         await closeCommand({ json: parsed.flags.json, tabId: globalTabId });


### PR DESCRIPTION
## Summary

- Add Chrome Dev, Canary, Beta, Arc to macOS browser candidate list (fixes #42)
- Remove obsolete daemon-era commands (`start`/`stop`/`status`/`reload`) that caused build failure
- Bump to v0.8.3

**Source:** https://x.com/normanmises_/status/2033374248862109929

## Test plan
- [x] `pnpm build` passes
- [ ] User with Chrome Dev (no standard Chrome) gets Chrome Dev launched instead of Edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)