### PR TITLE
fix(cli): execute network-capable adapters in Node to bypass CORS

### DIFF
--- a/packages/cli/src/commands/site.ts
+++ b/packages/cli/src/commands/site.ts
@@ -615,6 +615,51 @@ async function siteRun(
     }
   }
 
+  // Adapters with capabilities: ["network"] make cross-origin API calls that
+  // fail under page-context CORS/CSP. Execute them in Node instead where
+  // fetch() has no CORS restrictions.
+  const hasNetworkCap = site.capabilities?.includes("network");
+  if (hasNetworkCap) {
+    try {
+      const asyncFn = new Function(`return (async () => { return ${script}; })()`);
+      const result = await asyncFn();
+      let parsed: unknown = result;
+
+      if (typeof parsed === "object" && parsed !== null && "error" in parsed) {
+        const errObj = parsed as { error: string; hint?: string };
+        if (options.json) {
+          console.log(JSON.stringify({ id: generateId(), success: false, error: errObj.error, hint: errObj.hint }));
+        } else {
+          console.error(`[error] site ${name}: ${errObj.error}`);
+          if (errObj.hint) console.error(`  Hint: ${errObj.hint}`);
+        }
+        process.exit(1);
+      }
+
+      if (options.jq) {
+        const { applyJq } = await import("../jq.js");
+        const expr = options.jq.replace(/^\.data\./, '.');
+        const results = applyJq(parsed, expr);
+        for (const r of results) {
+          console.log(typeof r === "string" ? r : JSON.stringify(r));
+        }
+      } else if (options.json) {
+        console.log(JSON.stringify({ id: generateId(), success: true, data: parsed }));
+      } else {
+        console.log(JSON.stringify(parsed, null, 2));
+      }
+      return;
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      if (options.json) {
+        console.log(JSON.stringify({ id: generateId(), success: false, error: errMsg }));
+      } else {
+        console.error(`[error] site ${name}: ${errMsg}`);
+      }
+      process.exit(1);
+    }
+  }
+
   // 执行
   const evalReq: Request = { id: generateId(), action: "eval", script, tabId: targetTabId };
   const evalResp: Response = await sendCommand(evalReq);


### PR DESCRIPTION
## Summary

- Site adapters with `capabilities: ["network"]` (e.g. `hackernews/top`, `v2ex/hot`) make cross-origin API calls that fail with `TypeError: Failed to fetch` when executed via CDP `Runtime.evaluate` in page context, due to CORS/CSP restrictions
- Fix: detect `capabilities: ["network"]` in adapter metadata and execute the script directly in the Node process via `new Function()`, where `fetch()` has no CORS restrictions
- Adapters without the "network" capability continue to run via CDP in page context, preserving cookie-based auth

## Test plan

- [x] `bb-browser site hackernews/top 3` — returns JSON (was failing with CORS error)
- [x] `bb-browser site v2ex/hot` — returns JSON (cross-origin API)
- [x] `bb-browser eval "document.title"` — still works via CDP (regression check)
- [ ] `bb-browser site zhihu/hot` — runs via CDP with login cookies (no `network` capability)

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)