### PR TITLE
fix: sync CLI and MCP version metadata with package.json

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,7 +31,9 @@ import { siteCommand } from "./commands/site.js";
 import { historyCommand } from "./commands/history.js";
 import { setJqExpression } from "./client.js";
 
-const VERSION = "0.8.2";
+declare const __BB_BROWSER_VERSION__: string;
+
+const VERSION = __BB_BROWSER_VERSION__;
 
 const HELP_TEXT = `
 bb-browser - AI Agent 浏览器自动化工具

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -8,6 +8,8 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { z } from "zod";
 
+declare const __BB_BROWSER_VERSION__: string;
+
 const EXT_HINT = [
   "Chrome extension not connected.",
   "",
@@ -90,7 +92,7 @@ async function runCommand(request: Omit<Request, "id">) {
 }
 
 const server = new McpServer(
-  { name: "bb-browser", version: "0.4.0" },
+  { name: "bb-browser", version: __BB_BROWSER_VERSION__ },
   { instructions: `bb-browser lets you control the user's real Chrome browser — with their login state, cookies, and sessions.
 
 Your browser is the API. No headless browser, no cookie extraction, no anti-bot bypass.

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,9 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "tsup";
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf8"),
+) as { version: string };
 
 export default defineConfig({
   entry: {
@@ -15,6 +20,9 @@ export default defineConfig({
   outDir: "dist",
   banner: {
     js: "#!/usr/bin/env node",
+  },
+  define: {
+    __BB_BROWSER_VERSION__: JSON.stringify(packageJson.version),
   },
   // 全部 bundle 进去（npx 可用），只保留 ws（CommonJS 动态 require）
   noExternal: [/^(?!ws$).*/],


### PR DESCRIPTION
Closes #51

## Summary

- use the root package version as the single source of truth during tsup builds
- replace hardcoded version strings in the CLI and MCP entrypoints
- keep published user-facing version metadata aligned with `package.json`

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm build:release`
- `node dist/cli.js --version` -> `0.8.3`
- confirmed `dist/mcp.js` embeds `version: "0.8.3"` in MCP server metadata