### PR TITLE
fix: resolve installed package version at runtime

### DIFF
--- a/packages/cli/src/commands/site.ts
+++ b/packages/cli/src/commands/site.ts
@@ -21,6 +21,7 @@ import { readFileSync, readdirSync, existsSync, mkdirSync } from "node:fs";
 import { join, relative } from "node:path";
 import { homedir } from "node:os";
 import { execSync } from "node:child_process";
+import { CLI_VERSION } from "../version.js";
 
 const BB_DIR = join(homedir(), ".bb-browser");
 const LOCAL_SITES_DIR = join(BB_DIR, "sites");
@@ -29,7 +30,7 @@ const COMMUNITY_REPO = "https://github.com/epiral/bb-sites.git";
 
 function checkCliUpdate(): void {
   try {
-    const current = execSync("bb-browser --version", { timeout: 3000, stdio: ["pipe", "pipe", "pipe"] }).toString().trim();
+    const current = CLI_VERSION;
     const latest = execSync("npm view bb-browser version", { timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).toString().trim();
     if (latest && current && latest !== current && latest.localeCompare(current, undefined, { numeric: true }) > 0) {
       console.log(`\n📦 bb-browser ${latest} available (current: ${current}). Run: npm install -g bb-browser`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,10 +30,7 @@ import { fetchCommand } from "./commands/fetch.js";
 import { siteCommand } from "./commands/site.js";
 import { historyCommand } from "./commands/history.js";
 import { setJqExpression } from "./client.js";
-
-declare const __BB_BROWSER_VERSION__: string;
-
-const VERSION = __BB_BROWSER_VERSION__;
+import { CLI_VERSION } from "./version.js";
 
 const HELP_TEXT = `
 bb-browser - AI Agent 浏览器自动化工具
@@ -224,7 +221,7 @@ async function main(): Promise<void> {
 
   // 处理全局选项
   if (parsed.flags.version) {
-    console.log(VERSION);
+    console.log(CLI_VERSION);
     return;
   }
 

--- a/packages/cli/src/runtime-version.ts
+++ b/packages/cli/src/runtime-version.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface PackageJsonShape {
+  name?: string;
+  version?: string;
+}
+
+function readRootPackageVersion(filePath: string): string | null {
+  try {
+    const packageJson = JSON.parse(readFileSync(filePath, "utf8")) as PackageJsonShape;
+    if (packageJson.name !== "bb-browser") return null;
+    if (typeof packageJson.version !== "string" || packageJson.version.trim() === "") return null;
+    return packageJson.version.trim();
+  } catch {
+    return null;
+  }
+}
+
+export function getRuntimePackageVersion(moduleUrl: string, fallbackVersion: string): string {
+  let currentDir = dirname(fileURLToPath(moduleUrl));
+
+  for (let depth = 0; depth < 6; depth += 1) {
+    const version = readRootPackageVersion(resolve(currentDir, "package.json"));
+    if (version) return version;
+
+    const parentDir = resolve(currentDir, "..");
+    if (parentDir === currentDir) break;
+    currentDir = parentDir;
+  }
+
+  return fallbackVersion;
+}

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,5 @@
+import { getRuntimePackageVersion } from "./runtime-version.js";
+
+declare const __BB_BROWSER_VERSION__: string;
+
+export const CLI_VERSION = getRuntimePackageVersion(import.meta.url, __BB_BROWSER_VERSION__);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,8 +7,11 @@ import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { z } from "zod";
+import { getRuntimePackageVersion } from "./runtime-version.js";
 
 declare const __BB_BROWSER_VERSION__: string;
+
+const MCP_VERSION = getRuntimePackageVersion(import.meta.url, __BB_BROWSER_VERSION__);
 
 const EXT_HINT = [
   "Chrome extension not connected.",
@@ -92,7 +95,7 @@ async function runCommand(request: Omit<Request, "id">) {
 }
 
 const server = new McpServer(
-  { name: "bb-browser", version: __BB_BROWSER_VERSION__ },
+  { name: "bb-browser", version: MCP_VERSION },
   { instructions: `bb-browser lets you control the user's real Chrome browser — with their login state, cookies, and sessions.
 
 Your browser is the API. No headless browser, no cookie extraction, no anti-bot bypass.

--- a/packages/mcp/src/runtime-version.ts
+++ b/packages/mcp/src/runtime-version.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface PackageJsonShape {
+  name?: string;
+  version?: string;
+}
+
+function readRootPackageVersion(filePath: string): string | null {
+  try {
+    const packageJson = JSON.parse(readFileSync(filePath, "utf8")) as PackageJsonShape;
+    if (packageJson.name !== "bb-browser") return null;
+    if (typeof packageJson.version !== "string" || packageJson.version.trim() === "") return null;
+    return packageJson.version.trim();
+  } catch {
+    return null;
+  }
+}
+
+export function getRuntimePackageVersion(moduleUrl: string, fallbackVersion: string): string {
+  let currentDir = dirname(fileURLToPath(moduleUrl));
+
+  for (let depth = 0; depth < 6; depth += 1) {
+    const version = readRootPackageVersion(resolve(currentDir, "package.json"));
+    if (version) return version;
+
+    const parentDir = resolve(currentDir, "..");
+    if (parentDir === currentDir) break;
+    currentDir = parentDir;
+  }
+
+  return fallbackVersion;
+}


### PR DESCRIPTION
## Summary
- resolve the CLI version from the installed package at runtime instead of relying only on a build-time constant
- reuse the same runtime version in the site update notice so version checks stay consistent
- apply the same runtime version resolution to the MCP server metadata

## Verification
- pnpm build
- node dist/cli.js --version
- verified a copied release bundle reports the surrounding package.json version

Fixes #64