### PR TITLE
fix(cli): wire top-level status command

### DIFF
--- a/packages/cli/src/daemon-manager.ts
+++ b/packages/cli/src/daemon-manager.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { existsSync } from "node:fs";
 import { ensureCdpConnection } from "./cdp-client.js";
-import { discoverCdpPort } from "./cdp-discovery.js";
+import { isManagedBrowserRunning } from "./cdp-discovery.js";
 
 export function getDaemonPath(): string {
   const currentFile = fileURLToPath(import.meta.url);
@@ -19,7 +19,7 @@ export function getDaemonPath(): string {
 }
 
 export async function isDaemonRunning(): Promise<boolean> {
-  return (await discoverCdpPort()) !== null;
+  return await isManagedBrowserRunning();
 }
 
 export async function stopDaemon(): Promise<boolean> {
@@ -41,4 +41,3 @@ export async function ensureDaemonRunning(): Promise<void> {
     throw error;
   }
 }
-

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,6 +29,7 @@ import { traceCommand } from "./commands/trace.js";
 import { fetchCommand } from "./commands/fetch.js";
 import { siteCommand } from "./commands/site.js";
 import { historyCommand } from "./commands/history.js";
+import { statusCommand } from "./commands/daemon.js";
 import { setJqExpression } from "./client.js";
 
 declare const __BB_BROWSER_VERSION__: string;
@@ -476,6 +477,11 @@ async function main(): Promise<void> {
 
       case "tab": {
         await tabCommand(parsed.args, { json: parsed.flags.json });
+        break;
+      }
+
+      case "status": {
+        await statusCommand({ json: parsed.flags.json });
         break;
       }
 


### PR DESCRIPTION
## Summary
- add the documented top-level `status` CLI route
- keep status checks read-only by using the managed-browser probe instead of discovery that may launch/write state

## Testing
- `pnpm test`

Closes #68