### PR TITLE
feat(cli): support cdpUrl and cdpHost from OpenClaw

### DIFF
--- a/packages/cli/src/cdp-discovery.ts
+++ b/packages/cli/src/cdp-discovery.ts
@@ -9,6 +9,8 @@ const DEFAULT_CDP_PORT = 19825;
 const MANAGED_BROWSER_DIR = path.join(os.homedir(), ".bb-browser", "browser");
 const MANAGED_USER_DATA_DIR = path.join(MANAGED_BROWSER_DIR, "user-data");
 const MANAGED_PORT_FILE = path.join(MANAGED_BROWSER_DIR, "cdp-port");
+const CDP_CACHE_FILE = path.join(os.tmpdir(), "bb-browser-cdp-cache.json");
+const CACHE_TTL_MS = 30000; // 缓存有效期 30 秒
 
 function execFileAsync(command: string, args: string[], timeout: number): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -33,13 +35,15 @@ async function tryOpenClaw(): Promise<{ host: string; port: number } | null> {
     const raw = await execFileAsync("npx", ["openclaw", "browser", "status", "--json"], 30000);
     const parsed = parseOpenClawJson<{ cdpUrl?: string; cdpHost?: string; cdpPort?: number | string }>(raw);
 
+    let result: { host: string; port: number } | null = null;
+
     // 优先使用完整的 cdpUrl
     if (parsed?.cdpUrl) {
       try {
         const url = new URL(parsed.cdpUrl);
         const port = Number(url.port);
         if (Number.isInteger(port) && port > 0) {
-          return { host: url.hostname, port };
+          result = { host: url.hostname, port };
         }
       } catch {
         // cdpUrl 解析失败，继续尝试其他字段
@@ -47,11 +51,22 @@ async function tryOpenClaw(): Promise<{ host: string; port: number } | null> {
     }
 
     // 其次使用 cdpHost + cdpPort
-    const port = Number(parsed?.cdpPort);
-    if (Number.isInteger(port) && port > 0) {
-      const host = parsed?.cdpHost || "127.0.0.1";
-      return { host, port };
+    if (!result) {
+      const port = Number(parsed?.cdpPort);
+      if (Number.isInteger(port) && port > 0) {
+        const host = parsed?.cdpHost || "127.0.0.1";
+        result = { host, port };
+      }
     }
+
+    // 成功后写入缓存
+    if (result) {
+      try {
+        await writeFile(CDP_CACHE_FILE, JSON.stringify({ ...result, timestamp: Date.now() }), "utf8");
+      } catch {}
+    }
+
+    return result;
   } catch {
   }
   return null;
@@ -182,6 +197,19 @@ export async function launchManagedBrowser(port: number = DEFAULT_CDP_PORT): Pro
 }
 
 export async function discoverCdpPort(): Promise<{ host: string; port: number } | null> {
+  // 优先级1: 环境变量 BB_BROWSER_CDP_URL（最快，零延迟）
+  const envUrl = process.env.BB_BROWSER_CDP_URL;
+  if (envUrl) {
+    try {
+      const url = new URL(envUrl);
+      const port = Number(url.port);
+      if (Number.isInteger(port) && port > 0 && await canConnect(url.hostname, port)) {
+        return { host: url.hostname, port };
+      }
+    } catch {}
+  }
+
+  // 优先级2: 命令行 --port
   const explicitPort = Number.parseInt(getArgValue("--port") ?? "", 10);
   if (Number.isInteger(explicitPort) && explicitPort > 0 && await canConnect("127.0.0.1", explicitPort)) {
     return { host: "127.0.0.1", port: explicitPort };
@@ -196,6 +224,16 @@ export async function discoverCdpPort(): Promise<{ host: string; port: number } 
   } catch {
   }
 
+  // 优先级3: 文件缓存（避免重复执行 npx openclaw）
+  try {
+    const cacheRaw = await readFile(CDP_CACHE_FILE, "utf8");
+    const cache = JSON.parse(cacheRaw) as { host: string; port: number; timestamp: number };
+    if (Date.now() - cache.timestamp < CACHE_TTL_MS && await canConnect(cache.host, cache.port)) {
+      return { host: cache.host, port: cache.port };
+    }
+  } catch {}
+
+  // 优先级4: OpenClaw
   if (process.argv.includes("--openclaw")) {
     const viaOpenClaw = await tryOpenClaw();
     if (viaOpenClaw && await canConnect(viaOpenClaw.host, viaOpenClaw.port)) {
@@ -203,11 +241,13 @@ export async function discoverCdpPort(): Promise<{ host: string; port: number } 
     }
   }
 
+  // 优先级5: 自动启动浏览器
   const launched = await launchManagedBrowser();
   if (launched) {
     return launched;
   }
 
+  // 优先级6: 自动检测 OpenClaw（不带 --openclaw 参数时）
   if (!process.argv.includes("--openclaw")) {
     const detectedOpenClaw = await tryOpenClaw();
     if (detectedOpenClaw && await canConnect(detectedOpenClaw.host, detectedOpenClaw.port)) {


### PR DESCRIPTION
- Prioritize cdpUrl field for full CDP endpoint URL
- Fall back to cdpHost + cdpPort if cdpUrl not available
- cdpHost defaults to 127.0.0.1 when not specified