### PR TITLE
fix(cli): avoid double-inserting typed text

### DIFF
--- a/packages/cli/src/cdp-client.ts
+++ b/packages/cli/src/cdp-client.ts
@@ -608,29 +608,49 @@ async function insertTextIntoNode(targetId: string, backendNodeId: number, text:
 
   await sessionCommand(targetId, "Runtime.callFunctionOn", {
     objectId: resolved.object.objectId,
-    functionDeclaration: `function(value, clearFirst) {
-      if (typeof this.focus === 'function') this.focus();
-      if (clearFirst && ('value' in this)) {
-        this.value = '';
-        this.dispatchEvent(new Event('input', { bubbles: true }));
+    functionDeclaration: `function(clearFirst) {
+      if (typeof this.scrollIntoView === 'function') {
+        this.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'center' });
       }
-      if ('value' in this) {
-        this.value = clearFirst ? value : String(this.value ?? '') + value;
-        this.dispatchEvent(new Event('input', { bubbles: true }));
-        this.dispatchEvent(new Event('change', { bubbles: true }));
+      if (typeof this.focus === 'function') this.focus();
+      if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
+        if (clearFirst) {
+          this.value = '';
+          this.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        if (typeof this.setSelectionRange === 'function') {
+          const end = this.value.length;
+          this.setSelectionRange(end, end);
+        }
+        return true;
+      }
+      if (this instanceof HTMLElement && this.isContentEditable) {
+        if (clearFirst) {
+          this.textContent = '';
+          this.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+        const selection = window.getSelection();
+        if (selection) {
+          const range = document.createRange();
+          range.selectNodeContents(this);
+          range.collapse(false);
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
         return true;
       }
       return false;
     }`,
     arguments: [
-      { value: text },
       { value: clearFirst },
     ],
     returnByValue: true,
   });
 
-  await focusNode(targetId, backendNodeId);
-  await sessionCommand(targetId, "Input.insertText", { text });
+  if (text) {
+    await focusNode(targetId, backendNodeId);
+    await sessionCommand(targetId, "Input.insertText", { text });
+  }
 }
 
 async function getNodeBox(targetId: string, backendNodeId: number): Promise<{ x: number; y: number }> {


### PR DESCRIPTION
Closes #76

## Summary
- stop combining manual value mutation with `Input.insertText`
- keep `type` as a single append
- keep `fill` as clear-then-insert once

## Verification
- `pnpm build`
- `node dist/cli.js eval 'document.body.innerHTML = "<label>Name <input value=\"seed\"></label>"; "ok"' --json`
- `node dist/cli.js snapshot -i --json`
- `node dist/cli.js type 1 Z --json`
- `node dist/cli.js eval 'document.querySelector("input")?.value' --json` -> `seedZ`
- `node dist/cli.js eval 'document.querySelector("input").value = "seed"; document.querySelector("input")?.value' --json`
- `node dist/cli.js fill 1 ABC --json`
- `node dist/cli.js eval 'document.querySelector("input")?.value' --json` -> `ABC`
