### PR TITLE
feat(cli): add CDP monitor for persistent monitoring

### DIFF
--- a/packages/cli/src/cdp-monitor-state.ts
+++ b/packages/cli/src/cdp-monitor-state.ts
@@ -1,0 +1,182 @@
+/**
+ * MonitorState — reusable monitoring state for CDP events.
+ *
+ * Extracted from the event‐handling logic in cdp-client.ts so that the
+ * long‐running monitor process can accumulate network, console, error
+ * and trace data across multiple short‐lived CLI invocations.
+ */
+
+import type {
+  NetworkRequestInfo,
+  ConsoleMessageInfo,
+  JSErrorInfo,
+  TraceEvent,
+} from "@bb-browser/shared";
+
+type JsonObject = Record<string, unknown>;
+
+function normalizeHeaders(headers: unknown): Record<string, string> | undefined {
+  if (!headers || typeof headers !== "object") return undefined;
+  return Object.fromEntries(
+    Object.entries(headers as Record<string, unknown>).map(([key, value]) => [key, String(value)]),
+  );
+}
+
+export class MonitorState {
+  networkRequests = new Map<string, NetworkRequestInfo>();
+  networkEnabled = false;
+
+  consoleMessages: ConsoleMessageInfo[] = [];
+  consoleEnabled = false;
+
+  jsErrors: JSErrorInfo[] = [];
+  errorsEnabled = false;
+
+  traceRecording = false;
+  traceEvents: TraceEvent[] = [];
+
+  /**
+   * Feed a CDP session event (from any attached target) into the monitor
+   * state.  The method + params mirror what cdp-client.ts handles inside
+   * its own handleSessionEvent, but without any connection‐specific logic
+   * (dialog handling, etc.) that the monitor does not need.
+   */
+  handleSessionEvent(method: string, params: JsonObject): void {
+    if (method === "Network.requestWillBeSent") {
+      const requestId = typeof params.requestId === "string" ? params.requestId : undefined;
+      const request = params.request as JsonObject | undefined;
+      if (!requestId || !request) return;
+      this.networkRequests.set(requestId, {
+        requestId,
+        url: String(request.url ?? ""),
+        method: String(request.method ?? "GET"),
+        type: String(params.type ?? "Other"),
+        timestamp: Math.round(Number(params.timestamp ?? Date.now()) * 1000),
+        requestHeaders: normalizeHeaders(request.headers),
+        requestBody: typeof request.postData === "string" ? request.postData : undefined,
+      });
+      return;
+    }
+
+    if (method === "Network.responseReceived") {
+      const requestId = typeof params.requestId === "string" ? params.requestId : undefined;
+      const response = params.response as JsonObject | undefined;
+      if (!requestId || !response) return;
+      const existing = this.networkRequests.get(requestId);
+      if (!existing) return;
+      existing.status = typeof response.status === "number" ? response.status : undefined;
+      existing.statusText = typeof response.statusText === "string" ? response.statusText : undefined;
+      existing.responseHeaders = normalizeHeaders(response.headers);
+      existing.mimeType = typeof response.mimeType === "string" ? response.mimeType : undefined;
+      this.networkRequests.set(requestId, existing);
+      return;
+    }
+
+    if (method === "Network.loadingFailed") {
+      const requestId = typeof params.requestId === "string" ? params.requestId : undefined;
+      if (!requestId) return;
+      const existing = this.networkRequests.get(requestId);
+      if (!existing) return;
+      existing.failed = true;
+      existing.failureReason = typeof params.errorText === "string" ? params.errorText : "Unknown error";
+      this.networkRequests.set(requestId, existing);
+      return;
+    }
+
+    if (method === "Runtime.consoleAPICalled") {
+      const type = String(params.type ?? "log");
+      const args = Array.isArray(params.args) ? (params.args as JsonObject[]) : [];
+      const text = args
+        .map((arg) => {
+          if (typeof arg.value === "string") return arg.value;
+          if (arg.value !== undefined) return String(arg.value);
+          if (typeof arg.description === "string") return arg.description;
+          return "";
+        })
+        .filter(Boolean)
+        .join(" ");
+      const stack = params.stackTrace as JsonObject | undefined;
+      const firstCallFrame = Array.isArray(stack?.callFrames)
+        ? (stack?.callFrames[0] as JsonObject | undefined)
+        : undefined;
+      this.consoleMessages.push({
+        type: ["log", "info", "warn", "error", "debug"].includes(type)
+          ? (type as ConsoleMessageInfo["type"])
+          : "log",
+        text,
+        timestamp: Math.round(Number(params.timestamp ?? Date.now())),
+        url: typeof firstCallFrame?.url === "string" ? firstCallFrame.url : undefined,
+        lineNumber: typeof firstCallFrame?.lineNumber === "number" ? firstCallFrame.lineNumber : undefined,
+      });
+      return;
+    }
+
+    if (method === "Runtime.exceptionThrown") {
+      const details = params.exceptionDetails as JsonObject | undefined;
+      if (!details) return;
+      const exception = details.exception as JsonObject | undefined;
+      const stackTrace = details.stackTrace as JsonObject | undefined;
+      const callFrames = Array.isArray(stackTrace?.callFrames)
+        ? (stackTrace.callFrames as JsonObject[])
+        : [];
+      this.jsErrors.push({
+        message:
+          typeof exception?.description === "string"
+            ? exception.description
+            : String(details.text ?? "JavaScript exception"),
+        url:
+          typeof details.url === "string"
+            ? details.url
+            : typeof callFrames[0]?.url === "string"
+              ? String(callFrames[0].url)
+              : undefined,
+        lineNumber: typeof details.lineNumber === "number" ? details.lineNumber : undefined,
+        columnNumber: typeof details.columnNumber === "number" ? details.columnNumber : undefined,
+        stackTrace:
+          callFrames.length > 0
+            ? callFrames
+                .map(
+                  (frame) =>
+                    `${String(frame.functionName ?? "<anonymous>")} (${String(frame.url ?? "")}:${String(frame.lineNumber ?? 0)}:${String(frame.columnNumber ?? 0)})`,
+                )
+                .join("\n")
+            : undefined,
+        timestamp: Date.now(),
+      });
+    }
+  }
+
+  // --------------- clear helpers ---------------
+
+  clearNetwork(): void {
+    this.networkRequests.clear();
+  }
+
+  clearConsole(): void {
+    this.consoleMessages.length = 0;
+  }
+
+  clearErrors(): void {
+    this.jsErrors.length = 0;
+  }
+
+  // --------------- query helpers ---------------
+
+  getNetworkRequests(filter?: string): NetworkRequestInfo[] {
+    const all = Array.from(this.networkRequests.values());
+    if (!filter) return all;
+    return all.filter((item) => item.url.includes(filter));
+  }
+
+  getConsoleMessages(filter?: string): ConsoleMessageInfo[] {
+    if (!filter) return this.consoleMessages;
+    return this.consoleMessages.filter((item) => item.text.includes(filter));
+  }
+
+  getJsErrors(filter?: string): JSErrorInfo[] {
+    if (!filter) return this.jsErrors;
+    return this.jsErrors.filter(
+      (item) => item.message.includes(filter) || item.url?.includes(filter),
+    );
+  }
+}

--- a/packages/cli/src/cdp-monitor.ts
+++ b/packages/cli/src/cdp-monitor.ts
@@ -1,0 +1,521 @@
+/**
+ * cdp-monitor — long-running background process that maintains a persistent
+ * CDP connection and accumulates network / console / error / trace data.
+ *
+ * Spawned (detached) by monitor-manager.ts.  Communicates with short-lived
+ * CLI invocations via a tiny HTTP API on 127.0.0.1.
+ *
+ * Usage:
+ *   node cdp-monitor.js --cdp-host 127.0.0.1 --cdp-port 19825 \
+ *                        --monitor-port 19826 --token <hex>
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { request as httpRequest } from "node:http";
+import { mkdir, writeFile, unlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import WebSocket from "ws";
+import type { Request, Response, ResponseData, TraceStatus } from "@bb-browser/shared";
+import { MonitorState } from "./cdp-monitor-state.js";
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
+
+function getArg(flag: string, fallback: string): string {
+  const idx = process.argv.indexOf(flag);
+  if (idx < 0 || idx + 1 >= process.argv.length) return fallback;
+  return process.argv[idx + 1];
+}
+
+const CDP_HOST = getArg("--cdp-host", "127.0.0.1");
+const CDP_PORT = Number(getArg("--cdp-port", "19825"));
+const MONITOR_PORT = Number(getArg("--monitor-port", "19826"));
+const AUTH_TOKEN = getArg("--token", "");
+
+if (!AUTH_TOKEN) {
+  process.stderr.write("cdp-monitor: --token is required\n");
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const MONITOR_DIR = path.join(os.homedir(), ".bb-browser");
+const PID_FILE = path.join(MONITOR_DIR, "monitor.pid");
+const PORT_FILE = path.join(MONITOR_DIR, "monitor.port");
+const TOKEN_FILE = path.join(MONITOR_DIR, "monitor.token");
+
+// ---------------------------------------------------------------------------
+// Auto-exit timer (30 minutes without any HTTP request)
+// ---------------------------------------------------------------------------
+
+const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+function resetIdleTimer(): void {
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = setTimeout(() => {
+    shutdown("idle timeout");
+  }, IDLE_TIMEOUT_MS);
+  // Allow Node to exit naturally if nothing else holds it
+  if (idleTimer && typeof idleTimer === "object" && "unref" in idleTimer) {
+    // Do NOT unref the idle timer — we want it to keep the process alive
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CDP helpers (mirrored from cdp-client.ts — intentionally duplicated to
+// avoid coupling / risky refactor of cdp-client.ts in Phase 1)
+// ---------------------------------------------------------------------------
+
+type JsonObject = Record<string, unknown>;
+
+interface PendingCommand {
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+  method: string;
+}
+
+let browserSocket: WebSocket | null = null;
+let nextMessageId = 1;
+const browserPending = new Map<number, PendingCommand>();
+const sessions = new Map<string, string>(); // targetId -> sessionId
+const attachedTargets = new Map<string, string>(); // sessionId -> targetId
+
+const state = new MonitorState();
+const startTime = Date.now();
+
+// ---------------------------------------------------------------------------
+// CDP connection
+// ---------------------------------------------------------------------------
+
+function fetchJson(url: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(url, { method: "GET" }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+      res.on("end", () => {
+        const raw = Buffer.concat(chunks).toString("utf8");
+        if ((res.statusCode ?? 500) >= 400) {
+          reject(new Error(`HTTP ${res.statusCode ?? 500}: ${raw}`));
+          return;
+        }
+        try {
+          resolve(JSON.parse(raw));
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function connectWebSocket(url: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.once("open", () => resolve(ws));
+    ws.once("error", reject);
+  });
+}
+
+function browserCommand<T>(method: string, params: JsonObject = {}): Promise<T> {
+  if (!browserSocket) throw new Error("CDP not connected");
+  const id = nextMessageId++;
+  const payload = JSON.stringify({ id, method, params });
+  return new Promise<T>((resolve, reject) => {
+    browserPending.set(id, {
+      resolve: resolve as (v: unknown) => void,
+      reject,
+      method,
+    });
+    browserSocket!.send(payload);
+  });
+}
+
+function sessionCommand<T>(targetId: string, method: string, params: JsonObject = {}): Promise<T> {
+  if (!browserSocket) throw new Error("CDP not connected");
+  const sessionId = sessions.get(targetId);
+  if (!sessionId) throw new Error(`No session for target ${targetId}`);
+  const id = nextMessageId++;
+  const payload = JSON.stringify({ id, method, params, sessionId });
+  return new Promise<T>((resolve, reject) => {
+    const check = (raw: WebSocket.RawData) => {
+      const msg = JSON.parse(raw.toString()) as JsonObject;
+      if (msg.id === id && msg.sessionId === sessionId) {
+        browserSocket!.off("message", check);
+        if (msg.error) {
+          reject(new Error(`${method}: ${(msg.error as JsonObject).message ?? "Unknown CDP error"}`));
+        } else {
+          resolve(msg.result as T);
+        }
+      }
+    };
+    browserSocket!.on("message", check);
+    browserSocket!.send(payload);
+  });
+}
+
+async function attachAndEnable(targetId: string): Promise<void> {
+  if (sessions.has(targetId)) return;
+  const result = await browserCommand<{ sessionId: string }>("Target.attachToTarget", {
+    targetId,
+    flatten: true,
+  });
+  sessions.set(targetId, result.sessionId);
+  attachedTargets.set(result.sessionId, targetId);
+
+  // Enable domains the monitor cares about
+  await sessionCommand(targetId, "Network.enable").catch(() => {});
+  await sessionCommand(targetId, "Runtime.enable").catch(() => {});
+}
+
+function setupSocketListeners(ws: WebSocket): void {
+  ws.on("message", (raw) => {
+    const message = JSON.parse(raw.toString()) as JsonObject;
+
+    // Response to a browser-level command
+    if (typeof message.id === "number") {
+      const pending = browserPending.get(message.id);
+      if (!pending) return;
+      browserPending.delete(message.id);
+      if (message.error) {
+        pending.reject(
+          new Error(
+            `${pending.method}: ${(message.error as JsonObject).message ?? "Unknown CDP error"}`,
+          ),
+        );
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+
+    // Flat-mode attach notification
+    if (message.method === "Target.attachedToTarget") {
+      const params = message.params as JsonObject;
+      const sessionId = params.sessionId;
+      const targetInfo = params.targetInfo as JsonObject;
+      if (typeof sessionId === "string" && typeof targetInfo?.targetId === "string") {
+        sessions.set(targetInfo.targetId, sessionId);
+        attachedTargets.set(sessionId, targetInfo.targetId);
+      }
+      return;
+    }
+
+    if (message.method === "Target.detachedFromTarget") {
+      const params = message.params as JsonObject;
+      const sessionId = params.sessionId;
+      if (typeof sessionId === "string") {
+        const targetId = attachedTargets.get(sessionId);
+        if (targetId) {
+          sessions.delete(targetId);
+          attachedTargets.delete(sessionId);
+        }
+      }
+      return;
+    }
+
+    // New targets — auto-attach pages
+    if (message.method === "Target.targetCreated") {
+      const params = message.params as JsonObject;
+      const targetInfo = params.targetInfo as JsonObject;
+      if (targetInfo?.type === "page" && typeof targetInfo.targetId === "string") {
+        attachAndEnable(targetInfo.targetId).catch(() => {});
+      }
+      return;
+    }
+
+    // Flat protocol: session events carry sessionId directly
+    if (typeof message.sessionId === "string" && typeof message.method === "string") {
+      state.handleSessionEvent(message.method as string, (message.params ?? {}) as JsonObject);
+    }
+  });
+
+  ws.on("close", () => {
+    log("CDP connection closed — shutting down");
+    shutdown("cdp closed");
+  });
+
+  ws.on("error", (err) => {
+    log(`CDP error: ${err.message}`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Startup
+// ---------------------------------------------------------------------------
+
+async function connectCdp(): Promise<void> {
+  const versionData = (await fetchJson(`http://${CDP_HOST}:${CDP_PORT}/json/version`)) as JsonObject;
+  const wsUrl = versionData.webSocketDebuggerUrl;
+  if (typeof wsUrl !== "string" || !wsUrl) {
+    throw new Error("CDP endpoint missing webSocketDebuggerUrl");
+  }
+
+  const ws = await connectWebSocket(wsUrl);
+  browserSocket = ws;
+  setupSocketListeners(ws);
+
+  // Discover existing targets
+  await browserCommand("Target.setDiscoverTargets", { discover: true });
+  const result = await browserCommand<{
+    targetInfos: Array<{ targetId: string; type: string; title: string; url: string }>;
+  }>("Target.getTargets");
+
+  const pages = (result.targetInfos || []).filter((t) => t.type === "page");
+  for (const page of pages) {
+    await attachAndEnable(page.targetId).catch(() => {});
+  }
+
+  state.networkEnabled = true;
+  state.consoleEnabled = true;
+  state.errorsEnabled = true;
+
+  log(`Connected to CDP, monitoring ${pages.length} page(s)`);
+}
+
+// ---------------------------------------------------------------------------
+// Request handling
+// ---------------------------------------------------------------------------
+
+function ok(id: string, data?: ResponseData): Response {
+  return { id, success: true, data };
+}
+
+function fail(id: string, error: unknown): Response {
+  const msg = error instanceof Error ? error.message : String(error);
+  return { id, success: false, error: msg };
+}
+
+function handleCommand(request: Request): Response {
+  try {
+    switch (request.action) {
+      case "network": {
+        const sub = request.networkCommand ?? "requests";
+        switch (sub) {
+          case "requests": {
+            const requests = state.getNetworkRequests(request.filter);
+            // Note: withBody (fetching response bodies) requires a live
+            // session command which we could implement, but for Phase 1 we
+            // return what we have.
+            return ok(request.id, { networkRequests: requests });
+          }
+          case "clear":
+            state.clearNetwork();
+            return ok(request.id, {});
+          case "route":
+            return ok(request.id, { routeCount: 0 });
+          case "unroute":
+            return ok(request.id, { routeCount: 0 });
+          default:
+            return fail(request.id, `Unknown network subcommand: ${sub}`);
+        }
+      }
+
+      case "console": {
+        const sub = request.consoleCommand ?? "get";
+        switch (sub) {
+          case "get":
+            return ok(request.id, {
+              consoleMessages: state.getConsoleMessages(request.filter),
+            });
+          case "clear":
+            state.clearConsole();
+            return ok(request.id, {});
+          default:
+            return fail(request.id, `Unknown console subcommand: ${sub}`);
+        }
+      }
+
+      case "errors": {
+        const sub = request.errorsCommand ?? "get";
+        switch (sub) {
+          case "get":
+            return ok(request.id, {
+              jsErrors: state.getJsErrors(request.filter),
+            });
+          case "clear":
+            state.clearErrors();
+            return ok(request.id, {});
+          default:
+            return fail(request.id, `Unknown errors subcommand: ${sub}`);
+        }
+      }
+
+      case "trace": {
+        const sub = request.traceCommand ?? "status";
+        switch (sub) {
+          case "start":
+            state.traceRecording = true;
+            state.traceEvents.length = 0;
+            return ok(request.id, {
+              traceStatus: { recording: true, eventCount: 0 } satisfies TraceStatus,
+            });
+          case "stop": {
+            state.traceRecording = false;
+            return ok(request.id, {
+              traceEvents: [...state.traceEvents],
+              traceStatus: {
+                recording: false,
+                eventCount: state.traceEvents.length,
+              } satisfies TraceStatus,
+            });
+          }
+          case "status":
+            return ok(request.id, {
+              traceStatus: {
+                recording: state.traceRecording,
+                eventCount: state.traceEvents.length,
+              } satisfies TraceStatus,
+            });
+          default:
+            return fail(request.id, `Unknown trace subcommand: ${sub}`);
+        }
+      }
+
+      default:
+        return fail(request.id, `Monitor does not handle action: ${request.action}`);
+    }
+  } catch (error) {
+    return fail(request.id, error);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP server
+// ---------------------------------------------------------------------------
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+function jsonResponse(res: ServerResponse, status: number, body: unknown): void {
+  const data = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(data),
+  });
+  res.end(data);
+}
+
+function handleHttp(req: IncomingMessage, res: ServerResponse): void {
+  resetIdleTimer();
+
+  // Auth check
+  const authHeader = req.headers.authorization ?? "";
+  if (authHeader !== `Bearer ${AUTH_TOKEN}`) {
+    jsonResponse(res, 401, { error: "Unauthorized" });
+    return;
+  }
+
+  const url = req.url ?? "/";
+
+  if (req.method === "GET" && url === "/status") {
+    jsonResponse(res, 200, {
+      running: true,
+      cdpConnected: browserSocket !== null && browserSocket.readyState === WebSocket.OPEN,
+      uptimeMs: Date.now() - startTime,
+      counts: {
+        network: state.networkRequests.size,
+        console: state.consoleMessages.length,
+        errors: state.jsErrors.length,
+      },
+    });
+    return;
+  }
+
+  if (req.method === "POST" && url === "/command") {
+    readBody(req)
+      .then((body) => {
+        const request = JSON.parse(body) as Request;
+        const response = handleCommand(request);
+        jsonResponse(res, 200, response);
+      })
+      .catch((err) => {
+        jsonResponse(res, 400, { error: String(err) });
+      });
+    return;
+  }
+
+  if (req.method === "POST" && url === "/shutdown") {
+    jsonResponse(res, 200, { ok: true });
+    setTimeout(() => shutdown("shutdown requested"), 100);
+    return;
+  }
+
+  jsonResponse(res, 404, { error: "Not found" });
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+function log(msg: string): void {
+  process.stderr.write(`[cdp-monitor] ${msg}\n`);
+}
+
+async function writePidFiles(): Promise<void> {
+  await mkdir(MONITOR_DIR, { recursive: true });
+  await writeFile(PID_FILE, String(process.pid), { mode: 0o644 });
+  await writeFile(PORT_FILE, String(MONITOR_PORT), { mode: 0o644 });
+  await writeFile(TOKEN_FILE, AUTH_TOKEN, { mode: 0o600 });
+}
+
+async function cleanupPidFiles(): Promise<void> {
+  await unlink(PID_FILE).catch(() => {});
+  await unlink(PORT_FILE).catch(() => {});
+  await unlink(TOKEN_FILE).catch(() => {});
+}
+
+let shuttingDown = false;
+
+function shutdown(reason: string): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  log(`Shutting down: ${reason}`);
+  if (browserSocket) {
+    try {
+      browserSocket.close();
+    } catch {}
+  }
+  if (httpServer) {
+    httpServer.close();
+  }
+  cleanupPidFiles().finally(() => process.exit(0));
+}
+
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+
+let httpServer: ReturnType<typeof createServer> | null = null;
+
+async function main(): Promise<void> {
+  try {
+    await connectCdp();
+  } catch (error) {
+    log(`Failed to connect to CDP: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  httpServer = createServer(handleHttp);
+  httpServer.listen(MONITOR_PORT, "127.0.0.1", async () => {
+    log(`HTTP server listening on 127.0.0.1:${MONITOR_PORT}`);
+    await writePidFiles();
+    resetIdleTimer();
+  });
+}
+
+main().catch((err) => {
+  log(`Fatal: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -5,6 +5,9 @@
 import type { Request, Response } from "@bb-browser/shared";
 import { applyJq } from "./jq.js";
 import { sendCommand as sendCdpCommand } from "./cdp-client.js";
+import { monitorCommand } from "./monitor-manager.js";
+
+const MONITOR_ACTIONS = new Set(["network", "console", "errors", "trace"]);
 
 let jqExpression: string | undefined;
 
@@ -28,5 +31,13 @@ export function handleJqResponse(response: Response): void {
 }
 
 export async function sendCommand(request: Request): Promise<Response> {
+  if (MONITOR_ACTIONS.has(request.action)) {
+    try {
+      return await monitorCommand(request);
+    } catch {
+      // Fallback to direct CDP if monitor is unavailable
+      return sendCdpCommand(request);
+    }
+  }
   return sendCdpCommand(request);
 }

--- a/packages/cli/src/monitor-manager.ts
+++ b/packages/cli/src/monitor-manager.ts
@@ -1,0 +1,241 @@
+/**
+ * monitor-manager — CLI-side lifecycle management for the CDP monitor
+ * background process.
+ *
+ * Provides helpers to start / stop / query the monitor and to forward
+ * monitoring commands (network, console, errors, trace) to it.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdir, readFile, writeFile, unlink } from "node:fs/promises";
+import { request as httpRequest } from "node:http";
+import { randomBytes } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Request, Response } from "@bb-browser/shared";
+import { discoverCdpPort } from "./cdp-discovery.js";
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const MONITOR_DIR = path.join(os.homedir(), ".bb-browser");
+const PID_FILE = path.join(MONITOR_DIR, "monitor.pid");
+const PORT_FILE = path.join(MONITOR_DIR, "monitor.port");
+const TOKEN_FILE = path.join(MONITOR_DIR, "monitor.token");
+
+const DEFAULT_MONITOR_PORT = 19826;
+
+// ---------------------------------------------------------------------------
+// Low-level HTTP helpers
+// ---------------------------------------------------------------------------
+
+function httpJson<T>(
+  method: "GET" | "POST",
+  url: string,
+  token: string,
+  body?: unknown,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const payload = body !== undefined ? JSON.stringify(body) : undefined;
+    const req = httpRequest(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname,
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...(payload ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) } : {}),
+        },
+        timeout: 5000,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+        res.on("end", () => {
+          const raw = Buffer.concat(chunks).toString("utf8");
+          if ((res.statusCode ?? 500) >= 400) {
+            reject(new Error(`Monitor HTTP ${res.statusCode}: ${raw}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(raw) as T);
+          } catch {
+            reject(new Error(`Invalid JSON from monitor: ${raw}`));
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("Monitor request timed out"));
+    });
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// File helpers
+// ---------------------------------------------------------------------------
+
+async function readPortFile(): Promise<number | null> {
+  try {
+    const raw = await readFile(PORT_FILE, "utf8");
+    const port = Number.parseInt(raw.trim(), 10);
+    return Number.isInteger(port) && port > 0 ? port : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readTokenFile(): Promise<string | null> {
+  try {
+    return (await readFile(TOKEN_FILE, "utf8")).trim();
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function isMonitorRunning(): Promise<boolean> {
+  const port = await readPortFile();
+  const token = await readTokenFile();
+  if (!port || !token) return false;
+  try {
+    const result = await httpJson<{ running?: boolean }>(
+      "GET",
+      `http://127.0.0.1:${port}/status`,
+      token,
+    );
+    return result.running === true;
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureMonitorRunning(): Promise<{ port: number; token: string }> {
+  // Check if already running
+  const existingPort = await readPortFile();
+  const existingToken = await readTokenFile();
+  if (existingPort && existingToken) {
+    try {
+      const status = await httpJson<{ running?: boolean }>(
+        "GET",
+        `http://127.0.0.1:${existingPort}/status`,
+        existingToken,
+      );
+      if (status.running) {
+        return { port: existingPort, token: existingToken };
+      }
+    } catch {
+      // Not running — fall through to spawn
+    }
+  }
+
+  // Discover CDP port
+  const cdp = await discoverCdpPort();
+  if (!cdp) {
+    throw new Error("Cannot start monitor: no browser connection found");
+  }
+
+  const token = randomBytes(32).toString("hex");
+  const monitorPort = DEFAULT_MONITOR_PORT;
+
+  // Locate the monitor script
+  const monitorScript = findMonitorScript();
+
+  await mkdir(MONITOR_DIR, { recursive: true });
+  // Pre-write token so the CLI can read it immediately after spawn
+  await writeFile(TOKEN_FILE, token, { mode: 0o600 });
+
+  const child = spawn(process.execPath, [
+    monitorScript,
+    "--cdp-host", cdp.host,
+    "--cdp-port", String(cdp.port),
+    "--monitor-port", String(monitorPort),
+    "--token", token,
+  ], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+
+  // Wait for the monitor to become healthy (up to 5 seconds)
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 200));
+    try {
+      const status = await httpJson<{ running?: boolean }>(
+        "GET",
+        `http://127.0.0.1:${monitorPort}/status`,
+        token,
+      );
+      if (status.running) {
+        return { port: monitorPort, token };
+      }
+    } catch {
+      // Not ready yet
+    }
+  }
+
+  throw new Error("Monitor process did not start in time");
+}
+
+export async function stopMonitor(): Promise<void> {
+  const port = await readPortFile();
+  const token = await readTokenFile();
+  if (!port || !token) return;
+  try {
+    await httpJson("POST", `http://127.0.0.1:${port}/shutdown`, token);
+  } catch {
+    // Already stopped or unreachable — clean up files
+  }
+  await unlink(PID_FILE).catch(() => {});
+  await unlink(PORT_FILE).catch(() => {});
+  await unlink(TOKEN_FILE).catch(() => {});
+}
+
+export async function monitorCommand(request: Request): Promise<Response> {
+  const { port, token } = await ensureMonitorRunning();
+  return httpJson<Response>(
+    "POST",
+    `http://127.0.0.1:${port}/command`,
+    token,
+    request,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Locate the built cdp-monitor script
+// ---------------------------------------------------------------------------
+
+function findMonitorScript(): string {
+  const currentFile = fileURLToPath(import.meta.url);
+  const currentDir = dirname(currentFile);
+  const candidates = [
+    // Built output (tsup puts it next to cli.js)
+    resolve(currentDir, "cdp-monitor.js"),
+    // Development: packages/cli/src -> packages/cli/dist
+    resolve(currentDir, "../dist/cdp-monitor.js"),
+    // Monorepo root dist
+    resolve(currentDir, "../../dist/cdp-monitor.js"),
+    resolve(currentDir, "../../../dist/cdp-monitor.js"),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  // Fall back to the first candidate (will fail at spawn with a clear error)
+  return candidates[0];
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,6 +8,7 @@ const packageJson = JSON.parse(
 export default defineConfig({
   entry: {
     cli: "packages/cli/src/index.ts",
+    "cdp-monitor": "packages/cli/src/cdp-monitor.ts",
     daemon: "packages/daemon/src/index.ts",
     mcp: "packages/mcp/src/index.ts",
   },


### PR DESCRIPTION
Fixes #77. Partially addresses #37.

In direct CDP mode, each CLI invocation is a new process. Monitoring state resets every time. This adds a cdp-monitor background process that maintains a persistent CDP WebSocket, accumulates events, and serves them to CLI via HTTP.

Architecture: single-shot commands (eval, click) go direct CDP; monitoring commands (network, console, errors) go through cdp-monitor.

New files: cdp-monitor-state.ts, cdp-monitor.ts, monitor-manager.ts. Modified: client.ts (routing), tsup.config.ts (build entry).

Security: auth token (crypto.randomBytes), 127.0.0.1 only, Bearer header required.

Tested: auto-start, cross-process capture, filter, clear, console monitoring, page load capture, single-shot commands unaffected.