### PR TITLE
fix(cli): avoid global crypto for request ids

### DIFF
--- a/packages/cli/src/commands/console.ts
+++ b/packages/cli/src/commands/console.ts
@@ -2,6 +2,7 @@
  * console 命令 - 查看控制台消息
  */
 
+import { generateId } from "@bb-browser/shared";
 import { sendCommand } from "../client.js";
 
 interface ConsoleOptions {
@@ -12,7 +13,7 @@ interface ConsoleOptions {
 
 export async function consoleCommand(options: ConsoleOptions = {}): Promise<void> {
   const response = await sendCommand({
-    id: crypto.randomUUID(),
+    id: generateId(),
     action: "console",
     consoleCommand: options.clear ? "clear" : "get",
     tabId: options.tabId,

--- a/packages/cli/src/commands/errors.ts
+++ b/packages/cli/src/commands/errors.ts
@@ -2,6 +2,7 @@
  * errors 命令 - 查看 JS 错误
  */
 
+import { generateId } from "@bb-browser/shared";
 import { sendCommand } from "../client.js";
 
 interface ErrorsOptions {
@@ -12,7 +13,7 @@ interface ErrorsOptions {
 
 export async function errorsCommand(options: ErrorsOptions = {}): Promise<void> {
   const response = await sendCommand({
-    id: crypto.randomUUID(),
+    id: generateId(),
     action: "errors",
     errorsCommand: options.clear ? "clear" : "get",
     tabId: options.tabId,

--- a/packages/cli/src/commands/history.ts
+++ b/packages/cli/src/commands/history.ts
@@ -7,6 +7,7 @@
  */
 
 import { getHistoryDomains, searchHistory } from "../history-sqlite.js";
+import { generateId } from "@bb-browser/shared";
 
 interface HistoryOptions {
   json?: boolean;
@@ -25,7 +26,7 @@ export async function historyCommand(
 
   if (options.json) {
     console.log(JSON.stringify({
-      id: crypto.randomUUID(),
+      id: generateId(),
       success: true,
       data,
     }));

--- a/packages/cli/src/commands/network.ts
+++ b/packages/cli/src/commands/network.ts
@@ -2,6 +2,7 @@
  * network 命令 - 网络监控和拦截
  */
 
+import { generateId } from "@bb-browser/shared";
 import { sendCommand } from "../client.js";
 
 interface NetworkOptions {
@@ -18,7 +19,7 @@ export async function networkCommand(
   options: NetworkOptions = {}
 ): Promise<void> {
   const response = await sendCommand({
-    id: crypto.randomUUID(),
+    id: generateId(),
     action: "network",
     networkCommand: subCommand as "requests" | "route" | "unroute" | "clear",
     url: subCommand === "route" || subCommand === "unroute" ? urlOrFilter : undefined,

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -7,6 +7,7 @@
  *   bb-browser trace status  查看录制状态
  */
 
+import { generateId } from "@bb-browser/shared";
 import { sendCommand } from "../client.js";
 
 interface TraceOptions {
@@ -19,7 +20,7 @@ export async function traceCommand(
   options: TraceOptions = {}
 ): Promise<void> {
   const response = await sendCommand({
-    id: crypto.randomUUID(),
+    id: generateId(),
     action: "trace",
     traceCommand: subCommand,
     tabId: options.tabId,

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 /**
  * CLI 与 Chrome Extension 之间的通信协议类型定义
  */
@@ -332,5 +334,5 @@ export interface DaemonStatus {
  * @returns UUID v4 格式的字符串
  */
 export function generateId(): string {
-  return crypto.randomUUID();
+  return randomUUID();
 }


### PR DESCRIPTION
## Summary
- replace the remaining direct `crypto.randomUUID()` calls with the shared `generateId()` helper
- implement `generateId()` with `node:crypto` so request IDs work on early Node 18 where global `crypto` is not reliably available
- keep the existing `engines.node >=18.0.0` contract without changing runtime behavior

## Testing
- `pnpm build`
- `pnpm test`
- `npx -y node@18.0.0 --input-type=module -e "const mod = await import('./packages/shared/dist/index.js'); console.log(JSON.stringify({ id: mod.generateId(), ok: true }));"`

Fixes #75