### PR TITLE
fix(cli): restore daemon subcommand

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "tsx --test src/openclaw-json.test.ts src/openclaw-bridge.test.ts"
+    "test": "tsx --test src/openclaw-json.test.ts src/openclaw-bridge.test.ts src/daemon.test.ts"
   },
   "dependencies": {
     "@bb-browser/shared": "workspace:*"

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,8 +1,26 @@
-import { isDaemonRunning } from "../daemon-manager.js";
+import { spawn } from "node:child_process";
+import { getDaemonPath, isDaemonRunning } from "../daemon-manager.js";
 
 export interface DaemonOptions {
   json?: boolean;
   host?: string;
+}
+
+export async function daemonCommand(args: string[]): Promise<void> {
+  await new Promise<void>((_resolve, reject) => {
+    const child = spawn(process.execPath, [getDaemonPath(), ...args], {
+      stdio: "inherit",
+    });
+
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        reject(new Error(`Daemon exited with signal ${signal}`));
+        return;
+      }
+      process.exit(code ?? 0);
+    });
+  });
 }
 
 export async function statusCommand(

--- a/packages/cli/src/daemon.test.ts
+++ b/packages/cli/src/daemon.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const cliPath = resolve(currentDir, "../dist/index.js");
+
+test("daemon subcommand forwards help to the daemon entrypoint", () => {
+  const result = spawnSync(process.execPath, [cliPath, "daemon", "--help"], {
+    encoding: "utf-8",
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stderr, /bb-browser daemon - HTTP server daemon for bb-browser/);
+  assert.match(result.stderr, /bb-browser daemon \[options\]/);
+  assert.doesNotMatch(result.stdout + result.stderr, /AI Agent 浏览器自动化工具|已关闭当前标签页/);
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,7 +29,7 @@ import { traceCommand } from "./commands/trace.js";
 import { fetchCommand } from "./commands/fetch.js";
 import { siteCommand } from "./commands/site.js";
 import { historyCommand } from "./commands/history.js";
-import { statusCommand } from "./commands/daemon.js";
+import { daemonCommand, statusCommand } from "./commands/daemon.js";
 import { setJqExpression } from "./client.js";
 
 declare const __BB_BROWSER_VERSION__: string;
@@ -80,6 +80,9 @@ bb-browser - AI Agent 浏览器自动化工具
 标签页：
   tab [list|new|close|<n>]     管理标签页
   status                       查看受管浏览器状态
+
+服务：
+  daemon [--host <host>] [--port <port>]  前台启动 daemon
 
 导航：
   back / forward / refresh     后退 / 前进 / 刷新
@@ -210,6 +213,12 @@ function parseArgs(argv: string[]): ParsedArgs {
   return result;
 }
 
+function getCommandTailArgs(argv: string[], command: string): string[] {
+  const args = argv.slice(2);
+  const commandIndex = args.indexOf(command);
+  return commandIndex >= 0 ? args.slice(commandIndex + 1) : [];
+}
+
 /**
  * 主函数
  */
@@ -237,7 +246,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (parsed.flags.help || !parsed.command) {
+  if ((parsed.flags.help && parsed.command !== "daemon") || !parsed.command) {
     console.log(HELP_TEXT);
     return;
   }
@@ -407,7 +416,10 @@ async function main(): Promise<void> {
         break;
       }
 
-      case "daemon":
+      case "daemon": {
+        await daemonCommand(getCommandTailArgs(process.argv, "daemon"));
+        break;
+      }
 
       case "close": {
         await closeCommand({ json: parsed.flags.json, tabId: globalTabId });

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,4 +1,9 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "tsup";
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as { version: string };
 
 export default defineConfig({
   entry: ["src/index.ts"],
@@ -9,6 +14,9 @@ export default defineConfig({
   target: "node18",
   banner: {
     js: "#!/usr/bin/env node",
+  },
+  define: {
+    __BB_BROWSER_VERSION__: JSON.stringify(packageJson.version),
   },
   // ws 使用 Node.js 内置模块，需要标记为外部依赖
   external: ["ws"],

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -49,10 +49,10 @@ function parseOptions(): DaemonOptions {
 
   if (values.help) {
     console.error(`
-bb-browser-daemon - HTTP Server Daemon for bb-browser
+bb-browser daemon - HTTP server daemon for bb-browser
 
 Usage:
-  bb-browser-daemon [options]
+  bb-browser daemon [options]
 
 Options:
   -H, --host <host>  HTTP server host (default: ${DAEMON_HOST})


### PR DESCRIPTION
## Summary
- route `bb-browser daemon` to the packaged daemon entrypoint instead of falling through to `close`
- preserve daemon-only flags like `--host` and allow `bb-browser daemon --help` to show daemon help
- add a CLI regression test and inject the version constant in the package-local CLI build so the built test entrypoint is runnable

Closes #99.

## Verification
- `pnpm test`
- `pnpm build`
- `node dist/cli.js daemon --help`
- `node dist/cli.js daemon --host 127.0.0.1 --port 19999` and `curl http://127.0.0.1:19999/status`
