### PR TITLE
fix(cli): place OpenClaw browser flags before subcommand

### DIFF
--- a/packages/cli/src/openclaw-bridge.ts
+++ b/packages/cli/src/openclaw-bridge.ts
@@ -17,7 +17,17 @@ export function buildOpenClawArgs(args: string[], timeout: number): string[] {
     throw new Error("OpenClaw browser command requires a subcommand");
   }
 
-  return ["openclaw", "browser", subcommand, "--timeout", String(timeout), ...rest];
+  const browserLevelFlags: string[] = [];
+  const subcommandArgs: string[] = [];
+  for (const arg of rest) {
+    if (arg === "--json") {
+      browserLevelFlags.push(arg);
+      continue;
+    }
+    subcommandArgs.push(arg);
+  }
+
+  return ["openclaw", "browser", ...browserLevelFlags, "--timeout", String(timeout), subcommand, ...subcommandArgs];
 }
 
 export function getOpenClawExecTimeout(timeout: number): number {


### PR DESCRIPTION
## Summary

Fix `--openclaw` bridge compatibility with newer OpenClaw CLI versions where browser-level flags must appear before the browser subcommand.

## Problem

The bridge currently builds commands like:

```bash
openclaw browser tabs --timeout 15000 --json
```

On newer OpenClaw versions, `--timeout` / `--json` are browser-level options and must be placed before the subcommand, e.g.:

```bash
openclaw browser --json --timeout 15000 tabs
```

## Repro

```bash
bb-browser site zhihu/hot --openclaw
```

Actual failure:

```bash
Command failed: npx openclaw browser tabs --timeout 15000 --json
error: unknown option '--timeout'
```

## Root cause

`buildOpenClawArgs()` currently places browser-level flags after the subcommand.

## Fix

- split browser-level flags from subcommand args
- move `--json` before the browser subcommand
- keep `--timeout` at the browser command level

## Validation

These forms work against newer OpenClaw versions:

```bash
openclaw browser --json --timeout 15000 tabs
openclaw browser --json --timeout 15000 status
openclaw browser --json --timeout 30000 open https://example.com
```

And after this patch:

```bash
bb-browser site flomo/list 1 --openclaw --json
```

works again in the affected environment.

Closes #101
