### PR TITLE
docs: update MCP configuration to use bb-browser-mcp package

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,14 @@ For use without OpenClaw (Claude Code MCP, standalone CLI):
 {
   "mcpServers": {
     "bb-browser": {
+      "type": "stdio",
       "command": "npx",
-      "args": ["-y", "bb-browser", "--mcp"]
+      "args": [
+        "-y",
+        "--package",
+        "bb-browser",
+        "bb-browser-mcp"
+      ]
     }
   }
 }

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -84,8 +84,14 @@ ClawHub Skill: [bb-browser-openclaw](https://clawhub.ai/yan5xu/bb-browser)
 {
   "mcpServers": {
     "bb-browser": {
+      "type": "stdio",
       "command": "npx",
-      "args": ["-y", "bb-browser", "--mcp"]
+      "args": [
+        "-y",
+        "--package",
+        "bb-browser",
+        "bb-browser-mcp"
+      ]
     }
   }
 }

--- a/skills/bb-browser/SKILL.md
+++ b/skills/bb-browser/SKILL.md
@@ -308,8 +308,14 @@ bb-browser --mcp
 {
   "mcpServers": {
     "bb-browser": {
+      "type": "stdio",
       "command": "npx",
-      "args": ["-y", "bb-browser", "--mcp"]
+      "args": [
+        "-y",
+        "--package",
+        "bb-browser",
+        "bb-browser-mcp"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Update MCP configuration to use the dedicated `bb-browser-mcp` package instead of the `--mcp` flag.

## Changes

- Add explicit `"type": "stdio"` to MCP config
- Change from `"bb-browser", "--mcp"` to dedicated `"bb-browser-mcp"` command
- Update README.md, README.zh-CN.md, and skills/bb-browser/SKILL.md

## New Configuration

```json
{
  "mcpServers": {
    "bb-browser": {
      "type": "stdio",
      "command": "npx",
      "args": [
        "-y",
        "--package",
        "bb-browser",
        "bb-browser-mcp"
      ]
    }
  }
}
```

---

Resolves: #107