### PR TITLE
fix(extension): recover async eval result when Chrome returns objectId

### DIFF
--- a/packages/extension/src/background/cdp-service.ts
+++ b/packages/extension/src/background/cdp-service.ts
@@ -299,6 +299,20 @@ export async function evaluate(
     throw new Error(`Eval error: ${errorMsg}`);
   }
 
+  // When awaitPromise resolves an async function, Chrome may return an objectId
+  // instead of a serialized value even with returnByValue: true. Fall back to
+  // JSON.stringify via callFunctionOn to recover the actual value.
+  if (result.result?.value === undefined && result.result?.objectId) {
+    const serialized = await callFunctionOn(
+      tabId,
+      result.result.objectId,
+      'function() { try { return JSON.stringify(this); } catch(e) { return String(this); } }'
+    );
+    if (serialized !== undefined) {
+      try { return JSON.parse(serialized as string); } catch { return serialized; }
+    }
+  }
+
   return result.result?.value;
 }
 


### PR DESCRIPTION
## Problem

When `Runtime.evaluate` is called with `awaitPromise: true` on an async expression, Chrome occasionally resolves the Promise but returns the result as a remote object reference (`objectId`) rather than serializing it inline, even when `returnByValue: true` is set.

This causes `evaluate()` to return `undefined`, which callers then serialize as an empty object `{}`.

**Reproducer** (via the extension daemon at port 19824):
```bash
# Before fix
curl -s -X POST http://localhost:19824/command \
  -H "Content-Type: application/json" \
  -d '{"id":"t","action":"eval","script":"(async () => ({ test: 123, url: location.href }))()"}'
# → {"data":{"result":{}}}

# After fix
# → {"data":{"result":{"test":123,"url":"https://..."}}}
```

## Fix

Detect the `objectId` case after `awaitPromise` resolution and recover the value via `callFunctionOn` with `JSON.stringify`, then parse it back. This reuses the existing `callFunctionOn` helper already in the same file.

## Impact

Affects all callers that use `evaluate()` with async expressions — including all `bb-browser site` adapters that use `async function(args)` bodies when run through the extension daemon path.