### PR TITLE
feat: add --gstack mode for GStack Desktop integration

### DIFF
--- a/packages/cli/src/cdp-client.ts
+++ b/packages/cli/src/cdp-client.ts
@@ -119,6 +119,30 @@ function buildRequestError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
+function isCreateTargetUnsupported(error: unknown): boolean {
+  const message = buildRequestError(error).message;
+  return message.includes("Target.createTarget: Not supported")
+    || message.includes("'Target.createTarget' wasn't found")
+    || message.includes("Method not found");
+}
+
+async function createTargetWithFallback(url: string): Promise<string | null> {
+  try {
+    const created = await browserCommand<{ targetId: string }>("Target.createTarget", { url, background: true });
+    return created.targetId;
+  } catch (firstError) {
+    try {
+      const created = await browserCommand<{ targetId: string }>("Target.createTarget", { url });
+      return created.targetId;
+    } catch (secondError) {
+      if (isCreateTargetUnsupported(firstError) || isCreateTargetUnsupported(secondError)) {
+        return null;
+      }
+      throw secondError;
+    }
+  }
+}
+
 function fetchJson(url: string): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const requester = url.startsWith("https:") ? httpsRequest : httpRequest;
@@ -972,9 +996,15 @@ async function dispatchRequest(request: Request): Promise<Response> {
     case "open": {
       if (!request.url) return fail(request.id, "Missing url parameter");
       if (request.tabId === undefined) {
-        const created = await browserCommand<{ targetId: string }>("Target.createTarget", { url: request.url, background: true });
-        const newTarget = await ensurePageTarget(created.targetId);
-        return ok(request.id, { url: request.url, tabId: newTarget.id });
+        const createdTargetId = await createTargetWithFallback(request.url);
+        if (createdTargetId) {
+          const newTarget = await ensurePageTarget(createdTargetId);
+          return ok(request.id, { url: request.url, tabId: newTarget.id });
+        }
+        await pageCommand(target.id, "Page.navigate", { url: request.url });
+        connectionState?.refsByTarget.delete(target.id);
+        clearPersistedRefs(target.id);
+        return ok(request.id, { url: request.url, title: target.title, tabId: target.id });
       }
       await pageCommand(target.id, "Page.navigate", { url: request.url });
       connectionState?.refsByTarget.delete(target.id);
@@ -1086,8 +1116,10 @@ async function dispatchRequest(request: Request): Promise<Response> {
       return ok(request.id, { tabs, activeIndex: tabs.findIndex((tab) => tab.active) });
     }
     case "tab_new": {
-      const created = await browserCommand<{ targetId: string }>("Target.createTarget", { url: request.url ?? "about:blank", background: true });
-      return ok(request.id, { tabId: created.targetId, url: request.url ?? "about:blank" });
+      const targetUrl = request.url ?? "about:blank";
+      const createdTargetId = await createTargetWithFallback(targetUrl);
+      if (!createdTargetId) return fail(request.id, "Target.createTarget is not supported by current CDP runtime");
+      return ok(request.id, { tabId: createdTargetId, url: targetUrl });
     }
     case "tab_select": {
       const tabs = (await getTargets()).filter((item) => item.type === "page");

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -14,7 +14,7 @@ import { getSiteHintForDomain } from "./site.js";
 
 export interface OpenOptions {
   json?: boolean;
-  tab?: string;  // "current" | tabId 数字字符串 | undefined（新建 tab）
+  tab?: string;  // "current" | tabId（数字或字符串）| undefined（新建 tab）
 }
 
 export async function openCommand(
@@ -48,11 +48,8 @@ export async function openCommand(
       // 使用当前活动 tab
       (request as Record<string, unknown>).tabId = "current";
     } else {
-      // 使用指定 tabId
-      const tabId = parseInt(options.tab, 10);
-      if (isNaN(tabId)) {
-        throw new Error(`无效的 tabId: ${options.tab}`);
-      }
+      // 使用指定 tabId（兼容数字索引与字符串/UUID/hex id）
+      const tabId = /^\d+$/.test(options.tab) ? Number(options.tab) : options.tab;
       (request as Record<string, unknown>).tabId = tabId;
     }
   }

--- a/packages/cli/src/commands/site.ts
+++ b/packages/cli/src/commands/site.ts
@@ -43,6 +43,7 @@ export interface SiteOptions {
   days?: number;
   jq?: string;
   openclaw?: boolean;
+  gstack?: boolean;
 }
 
 /** Adapter 参数定义 */
@@ -637,6 +638,64 @@ async function siteRun(
       }
     } else if (options.json) {
       console.log(JSON.stringify({ id: "openclaw", success: true, data: parsed }));
+    } else {
+      console.log(JSON.stringify(parsed, null, 2));
+    }
+    return;
+  }
+
+  if (options.gstack) {
+    const { gstackGetTabs, gstackFindTabByDomain, gstackOpenTab, gstackEvaluate } = await import("../gstack-bridge.js");
+
+    let targetId: string;
+
+    if (site.domain) {
+      const tabs = gstackGetTabs();
+      const existing = gstackFindTabByDomain(tabs, site.domain);
+      if (existing) {
+        targetId = existing.targetId;
+      } else {
+        targetId = gstackOpenTab(`https://${site.domain}`);
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+      }
+    } else {
+      const tabs = gstackGetTabs();
+      if (tabs.length === 0) {
+        throw new Error("No tabs open in GStack Desktop browser");
+      }
+      targetId = tabs[0].targetId;
+    }
+
+    const wrappedFn = `async () => { const __fn = ${jsBody}; return await __fn(${argsJson}); }`;
+    const parsed = gstackEvaluate(targetId, wrappedFn);
+
+    if (typeof parsed === "object" && parsed !== null && "error" in parsed) {
+      const errObj = parsed as { error: string; hint?: string };
+      const checkText = `${errObj.error} ${errObj.hint || ""}`;
+      const isAuthError = /401|403|unauthorized|forbidden|not.?logged|login.?required|sign.?in|auth/i.test(checkText);
+      const loginHint = isAuthError && site.domain
+        ? `Please log in to https://${site.domain} in your GStack Desktop browser first, then retry.`
+        : undefined;
+      const hint = loginHint || errObj.hint;
+
+      if (options.json) {
+        console.log(JSON.stringify({ id: "gstack", success: false, error: errObj.error, hint }));
+      } else {
+        console.error(`[error] site ${name}: ${errObj.error}`);
+        if (hint) console.error(`  Hint: ${hint}`);
+      }
+      process.exit(1);
+    }
+
+    if (options.jq) {
+      const { applyJq } = await import("../jq.js");
+      const expr = options.jq.replace(/^\.data\./, '.');
+      const results = applyJq(parsed, expr);
+      for (const r of results) {
+        console.log(typeof r === "string" ? r : JSON.stringify(r));
+      }
+    } else if (options.json) {
+      console.log(JSON.stringify({ id: "gstack", success: true, data: parsed }));
     } else {
       console.log(JSON.stringify(parsed, null, 2));
     }

--- a/packages/cli/src/gstack-bridge.ts
+++ b/packages/cli/src/gstack-bridge.ts
@@ -1,0 +1,91 @@
+/**
+ * gstack-bridge — 通过 gstack CLI 与 Electron 主进程交互
+ *
+ * 与 openclaw-bridge.ts 对称：
+ *   openclaw-bridge → `npx openclaw browser <cmd>`
+ *   gstack-bridge   → `gstack browser <cmd>`
+ *
+ * gstack CLI 通过 Unix domain socket (~/.gstack/ipc.sock) 与 Electron 通信。
+ */
+
+import { execFileSync } from "node:child_process";
+
+const GSTACK_EVALUATE_TIMEOUT_MS = 120_000;
+const EXEC_TIMEOUT_BUFFER_MS = 5_000;
+
+export interface GstackTab {
+  index: number;
+  url: string;
+  title: string;
+  targetId: string;
+  type: string;
+}
+
+/** 定位 gstack CLI 可执行文件 */
+function resolveGstackBin(): string {
+  // 优先使用 PATH 中的 gstack
+  return "gstack";
+}
+
+export function buildGstackArgs(args: string[], timeout: number): string[] {
+  const [subcommand, ...rest] = args;
+  if (!subcommand) {
+    throw new Error("gstack browser command requires a subcommand");
+  }
+  // gstack CLI 不需要 --timeout（socket 通信本身快），但保留接口一致性
+  void timeout;
+  return ["browser", subcommand, ...rest];
+}
+
+export function getGstackExecTimeout(timeout: number): number {
+  return timeout + EXEC_TIMEOUT_BUFFER_MS;
+}
+
+function runGstack(args: string[], timeout: number): string {
+  return execFileSync(resolveGstackBin(), buildGstackArgs(args, timeout), {
+    encoding: "utf-8",
+    timeout: getGstackExecTimeout(timeout),
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim();
+}
+
+export function gstackGetTabs(): GstackTab[] {
+  const raw = runGstack(["tabs", "--json"], 15_000);
+  const data = JSON.parse(raw) as { tabs?: GstackTab[] };
+  return (data.tabs || []).filter((tab: GstackTab) => tab.type === "page");
+}
+
+export function gstackFindTabByDomain(tabs: GstackTab[], domain: string): GstackTab | undefined {
+  return tabs.find((tab) => {
+    try {
+      const hostname = new URL(tab.url).hostname;
+      return hostname === domain || hostname.endsWith(`.${domain}`);
+    } catch {
+      return false;
+    }
+  });
+}
+
+export function gstackOpenTab(url: string): string {
+  const raw = runGstack(["open", url, "--json"], 30_000);
+  const data = JSON.parse(raw) as { targetId?: string; success?: boolean };
+  return data.targetId || "default";
+}
+
+export function gstackEvaluate(targetId: string, fn: string): unknown {
+  const raw = runGstack(
+    ["evaluate", "--fn", fn, "--target-id", targetId],
+    GSTACK_EVALUATE_TIMEOUT_MS
+  );
+  return JSON.parse(raw);
+}
+
+export function gstackScreenshot(): { success: boolean; data?: string; error?: string } {
+  const raw = runGstack(["screenshot", "--json"], 30_000);
+  return JSON.parse(raw) as { success: boolean; data?: string; error?: string };
+}
+
+export function gstackNavigate(url: string): { success: boolean; url?: string; title?: string } {
+  const raw = runGstack(["navigate", url, "--json"], 30_000);
+  return JSON.parse(raw) as { success: boolean; url?: string; title?: string };
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,6 +36,119 @@ declare const __BB_BROWSER_VERSION__: string;
 
 const VERSION = __BB_BROWSER_VERSION__;
 
+/**
+ * gstack 命令拦截：对支持的命令走 Electron IPC，跳过 Daemon。
+ * @returns true 表示已处理，false 表示回退到 Daemon/CDP。
+ */
+async function handleGstackCommand(
+  command: string,
+  args: string[],
+  flags: { json?: boolean },
+): Promise<boolean> {
+  const {
+    gstackGetTabs,
+    gstackOpenTab,
+    gstackNavigate,
+    gstackScreenshot,
+    gstackEvaluate,
+  } = await import("./gstack-bridge.js");
+
+  const outputJson = (data: unknown) =>
+    flags.json
+      ? console.log(JSON.stringify(data, null, 2))
+      : console.log(JSON.stringify(data));
+
+  try {
+    switch (command) {
+      case "open": {
+        const url = args[0];
+        if (!url) {
+          console.error("错误：缺少 URL 参数");
+          process.exit(1);
+        }
+        const result = gstackNavigate(url);
+        outputJson({ success: true, data: result });
+        return true;
+      }
+
+      case "screenshot": {
+        const result = gstackScreenshot();
+        if (!result.success) {
+          outputJson(result);
+          process.exit(1);
+        }
+        // 若给了输出路径，保存文件
+        const outputPath = args[0];
+        if (outputPath && result.data) {
+          const fs = await import("node:fs");
+          const path = await import("node:path");
+          const dir = path.dirname(path.resolve(outputPath));
+          fs.mkdirSync(dir, { recursive: true });
+          fs.writeFileSync(path.resolve(outputPath), Buffer.from(result.data, "base64"));
+          if (!flags.json) {
+            console.log(`截图已保存: ${path.resolve(outputPath)}`);
+            return true;
+          }
+        }
+        outputJson(result);
+        return true;
+      }
+
+      case "tab": {
+        const subOrIndex = args[0];
+        if (!subOrIndex || subOrIndex === "list") {
+          const tabs = gstackGetTabs();
+          outputJson({ success: true, data: { tabs } });
+        } else if (/^\d+$/.test(subOrIndex)) {
+          // tab select — gstack IPC 目前只有单 automationView，直接返回当前
+          const tabs = gstackGetTabs();
+          outputJson({ success: true, data: { tabs, selected: Number(subOrIndex) } });
+        } else {
+          return false; // new, close 等子命令回退 Daemon
+        }
+        return true;
+      }
+
+      case "eval": {
+        const script = args[0];
+        if (!script) {
+          console.error("错误：缺少 script 参数");
+          process.exit(1);
+        }
+        const result = gstackEvaluate("default", script);
+        outputJson({ success: true, data: { result } });
+        return true;
+      }
+
+      case "back":
+      case "forward":
+      case "refresh": {
+        // 通过 evaluate 实现导航
+        const navJs: Record<string, string> = {
+          back: "history.back()",
+          forward: "history.forward()",
+          refresh: "location.reload()",
+        };
+        gstackEvaluate("default", navJs[command]!);
+        outputJson({ success: true });
+        return true;
+      }
+
+      // click, fill, snapshot 等需要 Playwright 的命令不拦截
+      default:
+        return false;
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (flags.json) {
+      console.log(JSON.stringify({ success: false, error: msg }));
+    } else {
+      console.error(`gstack 错误: ${msg}`);
+    }
+    process.exit(1);
+  }
+}
+
 const HELP_TEXT = `
 bb-browser - AI Agent 浏览器自动化工具
 
@@ -95,6 +208,7 @@ bb-browser - AI Agent 浏览器自动化工具
   --json               以 JSON 格式输出
   --port <n>           指定 Chrome CDP 端口
   --openclaw           优先复用 OpenClaw 浏览器实例
+  --gstack             优先复用 GStack Desktop 浏览器实例（Electron IPC）
   --jq <expr>          对 JSON 输出应用 jq 过滤（直接作用于数据，跳过 id/success 信封）
   -i, --interactive    只输出可交互元素（snapshot 命令）
   -c, --compact        移除空结构节点（snapshot 命令）
@@ -121,6 +235,7 @@ interface ParsedArgs {
     days?: number;
     jq?: string;
     openclaw?: boolean;
+    gstack?: boolean;
     port?: number;
   };
 }
@@ -160,6 +275,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       }
     } else if (arg === "--openclaw") {
       result.flags.openclaw = true;
+    } else if (arg === "--gstack") {
+      result.flags.gstack = true;
     } else if (arg === "--port") {
       skipNext = true;
       const nextIdx = args.indexOf(arg) + 1;
@@ -219,9 +336,16 @@ async function main(): Promise<void> {
 
   // 解析全局 --tab 参数
   const tabArgIdx = process.argv.indexOf('--tab');
-  const globalTabId = tabArgIdx >= 0 && process.argv[tabArgIdx + 1]
-    ? parseInt(process.argv[tabArgIdx + 1], 10)
+  const globalTabRaw = tabArgIdx >= 0 && process.argv[tabArgIdx + 1]
+    ? process.argv[tabArgIdx + 1]
     : undefined;
+  const globalTabId = globalTabRaw === undefined
+    ? undefined
+    : Number(globalTabRaw);
+  if (globalTabId !== undefined && Number.isNaN(globalTabId)) {
+    console.error(`Invalid --tab value: ${globalTabRaw}`);
+    process.exit(1);
+  }
 
   // 处理全局选项
   if (parsed.flags.version) {
@@ -240,6 +364,14 @@ async function main(): Promise<void> {
   if (parsed.flags.help || !parsed.command) {
     console.log(HELP_TEXT);
     return;
+  }
+
+  // ── gstack 拦截层 ──
+  // 当 --gstack 传入时，对支持的命令直接走 gstack-bridge（Electron IPC），跳过 Daemon。
+  if (parsed.flags.gstack && parsed.command) {
+    const handled = await handleGstackCommand(parsed.command, parsed.args, parsed.flags);
+    if (handled) return;
+    // 未处理的命令回退到 Daemon/CDP 路径
   }
 
   // 路由到对应命令
@@ -608,6 +740,7 @@ async function main(): Promise<void> {
           days: parsed.flags.days,
           tabId: globalTabId,
           openclaw: parsed.flags.openclaw,
+          gstack: parsed.flags.gstack,
         });
         break;
       }


### PR DESCRIPTION
## Summary

Add a new `--gstack` flag that routes browser commands through GStack Desktop's Unix domain socket IPC instead of discovering a CDP endpoint automatically.

This enables bb-browser CLI to drive an Electron-based desktop app (GStack Desktop) via its IPC interface, while preserving full CDP fallback for unsupported operations.

## Changes

| File | Description |
|------|-------------|
| `packages/cli/src/gstack-bridge.ts` | **New** — Bridge module (`execFileSync` → gstack CLI → IPC socket). Exports: `gstackGetTabs`, `gstackFindTabByDomain`, `gstackOpenTab`, `gstackEvaluate`, `gstackScreenshot`, `gstackNavigate` |
| `packages/cli/src/index.ts` | `--gstack` flag parsing, `handleGstackCommand()` intercept layer in `main()` — supported commands: open, screenshot, tab, eval, back/forward/refresh; unsupported commands fall through to CDP |
| `packages/cli/src/commands/site.ts` | GStack execution path in `siteRun()` — tab discovery by domain → open if needed → evaluate adapter script → auth error detection |
| `packages/cli/src/cdp-client.ts` | `createTargetWithFallback()` — gracefully handles runtimes where `Target.createTarget` is not supported (e.g. some Electron builds) |
| `packages/cli/src/commands/open.ts` | Relax `tabId` parsing to accept both numeric index and string/UUID IDs |

## How it works

```
bb open https://example.com --gstack
#  → gstack CLI → Unix socket (~/.gstack/ipc.sock) → Electron IPC → BrowserWindow
```

When `--gstack` is set:
1. `handleGstackCommand()` intercepts known commands and routes them via `gstack-bridge.ts`
2. Unknown commands fall through to the normal CDP dispatch path
3. `site` command uses gstack tab discovery + evaluate instead of CDP Runtime.evaluate

## Testing

- Build: `pnpm build` passes with zero TS errors
- Runtime verified: IPC ping, snapshot, click, fill, evaluate all working
- CDP fallback verified: snapshot, click, fill work normally when `--gstack` is not set