### PR TITLE
fix(cli): prefer daemon+extension path over direct CDP

### DIFF
--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -1,15 +1,25 @@
 /**
  * CDP 客户端 - 与 Chrome DevTools Protocol 通信
+ *
+ * 支持两种连接路径：
+ * 1. Daemon 模式：CLI → Daemon (HTTP:19824) → Chrome Extension → 用户真实浏览器
+ * 2. CDP 直连模式：CLI → Managed Chrome (CDP WebSocket)
+ *
+ * 优先使用 Daemon 模式（可操控用户真实浏览器的登录态），
+ * 不可用时回退到 CDP 直连。
  */
 
+import { request as httpRequest } from "node:http";
 import type { Request, Response } from "@bb-browser/shared";
 import { applyJq } from "./jq.js";
 import { sendCommand as sendCdpCommand } from "./cdp-client.js";
 import { monitorCommand } from "./monitor-manager.js";
 
 const MONITOR_ACTIONS = new Set(["network", "console", "errors", "trace"]);
+const DAEMON_URL = "http://127.0.0.1:19824";
 
 let jqExpression: string | undefined;
+let daemonAvailable: boolean | null = null;
 
 export function setJqExpression(expression?: string): void {
   jqExpression = expression;
@@ -30,14 +40,72 @@ export function handleJqResponse(response: Response): void {
   }
 }
 
+async function isDaemonConnected(): Promise<boolean> {
+  if (daemonAvailable !== null) return daemonAvailable;
+  try {
+    const res = await fetchJson(`${DAEMON_URL}/status`);
+    daemonAvailable = res.running === true && res.extensionConnected === true;
+  } catch {
+    daemonAvailable = false;
+  }
+  return daemonAvailable;
+}
+
+function fetchJson(url: string): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const req = httpRequest(url, { timeout: 1500 }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (c: Buffer) => chunks.push(c));
+      res.on("end", () => {
+        try { resolve(JSON.parse(Buffer.concat(chunks).toString())); }
+        catch (e) { reject(e); }
+      });
+    });
+    req.on("error", reject);
+    req.on("timeout", () => { req.destroy(); reject(new Error("timeout")); });
+    req.end();
+  });
+}
+
+function postJson(url: string, body: unknown): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const data = JSON.stringify(body);
+    const req = httpRequest(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(data) },
+      timeout: 60000,
+    }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (c: Buffer) => chunks.push(c));
+      res.on("end", () => {
+        try { resolve(JSON.parse(Buffer.concat(chunks).toString())); }
+        catch (e) { reject(e); }
+      });
+    });
+    req.on("error", reject);
+    req.on("timeout", () => { req.destroy(); reject(new Error("timeout")); });
+    req.write(data);
+    req.end();
+  });
+}
+
+async function sendDaemonCommand(request: Request): Promise<Response> {
+  return await postJson(`${DAEMON_URL}/command`, request) as Response;
+}
+
 export async function sendCommand(request: Request): Promise<Response> {
   if (MONITOR_ACTIONS.has(request.action)) {
     try {
       return await monitorCommand(request);
     } catch {
       // Fallback to direct CDP if monitor is unavailable
-      return sendCdpCommand(request);
     }
   }
+
+  // Prefer daemon+extension path (uses real browser with login state)
+  if (await isDaemonConnected()) {
+    return sendDaemonCommand(request);
+  }
+
   return sendCdpCommand(request);
 }


### PR DESCRIPTION
## Summary

- The daemon/extension architecture (CLI → Daemon:19824 → Chrome Extension → real browser) exists but the CLI never uses it — `sendCommand()` always calls `sendCdpCommand()` directly
- This means users can't leverage their real browser's login state, and must re-login in the managed Chrome instance
- Add daemon detection: if daemon is running and extension is connected, route commands through `POST /command`; otherwise fall back to direct CDP

## Changes

- `packages/cli/src/client.ts`: Add `isDaemonConnected()` check and `sendDaemonCommand()` path before falling back to `sendCdpCommand()`

## Test

```bash
# Start daemon with IPv4 binding
node packages/daemon/dist/index.js --host 127.0.0.1 &

# Install Chrome Extension, open x.com in real Chrome

# Verify extension connected
curl http://127.0.0.1:19824/status
# {"running":true,"extensionConnected":true,...}

# Commands now go through real Chrome with login state
bb-browser site twitter/search "Claude Code"
# Returns 20 tweets using real Chrome's x.com session
```