### PR TITLE
fix(extension): async eval returns empty result via daemon/MCP path

### DIFF
--- a/packages/extension/src/background/cdp-service.ts
+++ b/packages/extension/src/background/cdp-service.ts
@@ -289,7 +289,6 @@ export async function evaluate(
     expression,
     returnByValue: options.returnByValue ?? true,
     awaitPromise: options.awaitPromise ?? true,
-    replMode: true,
   });
 
   if (result.exceptionDetails) {
@@ -299,7 +298,7 @@ export async function evaluate(
     throw new Error(`Eval error: ${errorMsg}`);
   }
 
-  return result.result?.value;
+  return result.result?.value ?? result.result;
 }
 
 /**
@@ -323,7 +322,7 @@ export async function callFunctionOn(
     throw new Error(result.exceptionDetails.exception?.description || 'Call failed');
   }
 
-  return result.result?.value;
+  return result.result?.value ?? result.result;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- `Runtime.evaluate` with `replMode: true` causes async function return values to be lost in the extension's `cdp-service.ts`
- `result.result.value` is undefined for awaited promises with `replMode`, so the response becomes `{}` after JSON serialization
- This affects all daemon/extension consumers including MCP mode (`bb-browser --mcp`)

## Changes

- Remove `replMode: true` from `evaluate()` — `awaitPromise: true` already handles async
- Add `?? result.result` fallback to match CLI's `cdp-client.ts` behavior (line 636)
- Apply same fallback to `callFunctionOn()`

## Root Cause

The CLI's direct CDP path (`cdp-client.ts:636`) uses:
```typescript
return (result.result.value ?? result.result) as T;  // has fallback
```

The extension's path (`cdp-service.ts:302`) used:
```typescript
return result.result?.value;  // no fallback, undefined for async results
```

## Test

```bash
# Start daemon
node packages/daemon/dist/index.js --host 127.0.0.1 &

# Before fix: returns {}
curl -X POST http://127.0.0.1:19824/command \
  -d '{"id":"1","action":"eval","script":"(async()=>({count:42}))()","tabId":TAB_ID}'
# {"data":{"result":{}}}

# After fix: returns correct value
# {"data":{"result":{"count":42}}}
```