### PR TITLE
fix: bypass HTTP proxy for local CDP connections

### DIFF
--- a/packages/cli/src/cdp-client.ts
+++ b/packages/cli/src/cdp-client.ts
@@ -967,15 +967,16 @@ export async function sendCommand(request: Request): Promise<Response> {
 }
 
 async function dispatchRequest(request: Request): Promise<Response> {
+  if (request.action === "open" && !request.tabId) {
+    if (!request.url) return fail(request.id, "Missing url parameter");
+    const created = await browserCommand<{ targetId: string }>("Target.createTarget", { url: request.url, background: true });
+    const newTarget = await ensurePageTarget(created.targetId);
+    return ok(request.id, { url: request.url, tabId: newTarget.id });
+  }
   const target = await ensurePageTarget(request.tabId);
   switch (request.action) {
     case "open": {
       if (!request.url) return fail(request.id, "Missing url parameter");
-      if (request.tabId === undefined) {
-        const created = await browserCommand<{ targetId: string }>("Target.createTarget", { url: request.url, background: true });
-        const newTarget = await ensurePageTarget(created.targetId);
-        return ok(request.id, { url: request.url, tabId: newTarget.id });
-      }
       await pageCommand(target.id, "Page.navigate", { url: request.url });
       connectionState?.refsByTarget.delete(target.id);
       clearPersistedRefs(target.id);

--- a/packages/cli/src/cdp-discovery.ts
+++ b/packages/cli/src/cdp-discovery.ts
@@ -1,6 +1,7 @@
 import { execFile, execSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { request as httpRequest } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { parseOpenClawJson } from "./openclaw-json.js";
@@ -42,15 +43,16 @@ async function tryOpenClaw(): Promise<{ host: string; port: number } | null> {
 }
 
 async function canConnect(host: string, port: number): Promise<boolean> {
-  try {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 1200);
-    const response = await fetch(`http://${host}:${port}/json/version`, { signal: controller.signal });
-    clearTimeout(timeout);
-    return response.ok;
-  } catch {
-    return false;
-  }
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => { req.destroy(); resolve(false); }, 1200);
+    const req = httpRequest(`http://${host}:${port}/json/version`, { method: "GET" }, (res) => {
+      clearTimeout(timeout);
+      res.resume();
+      resolve((res.statusCode ?? 500) < 400);
+    });
+    req.on("error", () => { clearTimeout(timeout); resolve(false); });
+    req.end();
+  });
 }
 
 export function findBrowserExecutable(): string | null {


### PR DESCRIPTION
## Summary

- **Replace `fetch` with `node:http`** in `canConnect()` (`cdp-discovery.ts`) so CDP port discovery talks directly to localhost instead of being routed through `http_proxy` / `HTTP_PROXY`. This fixes CLI failing with "No page target found" when a proxy (e.g. Clash, v2ray on `127.0.0.1:7890`) is configured.
- **Move `open` command's create-tab path before `ensurePageTarget()`** (`cdp-client.ts`) so `bb-browser open <url>` works on a freshly launched managed browser that has no existing page targets — previously it threw "No page target found" before ever getting a chance to create one.

## Root cause

`canConnect()` used the global `fetch()` API, which respects `http_proxy` env vars. When a user has a proxy configured (common in China/Japan for accessing international sites), all localhost CDP requests (`http://127.0.0.1:19825/json/version`) get routed through the proxy, which either times out or returns 502. The rest of the CLI (`cdp-client.ts`) already uses `node:http` which is unaffected.

## Test plan

- [x] `bb-browser open <url>` works with `http_proxy` set to a local proxy
- [x] `bb-browser open <url>` works on managed browser with no existing tabs
- [x] `bb-browser snapshot` works after opening a page
- [ ] Existing CDP operations unchanged when no proxy is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)