### PR TITLE
fix: align daemon host defaults and restore daemon command

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ bb-browser site info xueqiu/stock   # view adapter args, example, domain
 
 ## Daemon configuration
 
-The daemon binds to `localhost:19824` by default. You can customize the host with `--host`:
+The daemon binds to `127.0.0.1:19824` by default. You can customize the host with `--host`:
 
 ```bash
 bb-browser daemon --host 127.0.0.1    # IPv4 only (fix macOS IPv6 issues)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -165,7 +165,7 @@ bb-browser site info xueqiu/stock   # 查看 adapter 参数、示例、域名
 
 ## Daemon 配置
 
-Daemon 默认绑定 `localhost:19824`，可通过 `--host` 自定义监听地址：
+Daemon 默认绑定 `127.0.0.1:19824`，可通过 `--host` 自定义监听地址：
 
 ```bash
 bb-browser daemon --host 127.0.0.1    # 仅 IPv4（解决 macOS IPv6 问题）

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,7 +29,8 @@ import { traceCommand } from "./commands/trace.js";
 import { fetchCommand } from "./commands/fetch.js";
 import { siteCommand } from "./commands/site.js";
 import { historyCommand } from "./commands/history.js";
-import { statusCommand } from "./commands/daemon.js";
+import { shutdownCommand, statusCommand } from "./commands/daemon.js";
+import { getDaemonPath } from "./daemon-manager.js";
 import { setJqExpression } from "./client.js";
 
 declare const __BB_BROWSER_VERSION__: string;
@@ -90,6 +91,7 @@ bb-browser - AI Agent 浏览器自动化工具
   errors [--clear]             查看/清空 JS 错误
   trace start|stop|status      录制用户操作
   history search|domains       查看浏览历史
+  daemon [status|stop] [opts]  前台运行或管理 daemon
 
 选项：
   --json               以 JSON 格式输出
@@ -253,7 +255,12 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (parsed.flags.help || !parsed.command) {
+  if (!parsed.command) {
+    console.log(HELP_TEXT);
+    return;
+  }
+
+  if (parsed.flags.help && parsed.command !== "daemon") {
     console.log(HELP_TEXT);
     return;
   }
@@ -423,7 +430,32 @@ async function main(): Promise<void> {
         break;
       }
 
-      case "daemon":
+      case "daemon": {
+        const daemonSubcommand = parsed.args[0];
+        if (daemonSubcommand === "status") {
+          await statusCommand({ json: parsed.flags.json });
+          break;
+        }
+        if (daemonSubcommand === "stop" || daemonSubcommand === "shutdown") {
+          await shutdownCommand({ json: parsed.flags.json });
+          break;
+        }
+
+        const daemonPath = getDaemonPath();
+        const daemonArgs = process.argv.slice(3);
+        const { spawn } = await import("node:child_process");
+        const child = spawn(process.execPath, [daemonPath, ...daemonArgs], {
+          stdio: "inherit",
+        });
+        child.on("exit", (code, signal) => {
+          if (signal) {
+            process.kill(process.pid, signal);
+            return;
+          }
+          process.exit(code ?? 0);
+        });
+        return;
+      }
 
       case "close": {
         await closeCommand({ json: parsed.flags.json, tabId: globalTabId });

--- a/packages/extension/options.html
+++ b/packages/extension/options.html
@@ -17,8 +17,8 @@
 <body>
   <h1>bb-browser Settings</h1>
   <label for="url">Upstream URL</label>
-  <input type="text" id="url" placeholder="http://localhost:19824">
-  <div class="hint">Leave empty to use default (http://localhost:19824)</div>
+  <input type="text" id="url" placeholder="http://127.0.0.1:19824">
+  <div class="hint">Leave empty to use default (http://127.0.0.1:19824)</div>
   <button id="save">Save</button>
   <div class="status" id="status"></div>
   <script src="options.js"></script>

--- a/packages/extension/src/background/constants.ts
+++ b/packages/extension/src/background/constants.ts
@@ -3,7 +3,7 @@
  */
 
 export const DEFAULT_DAEMON_PORT = 19824;
-export const DEFAULT_DAEMON_HOST = 'localhost';
+export const DEFAULT_DAEMON_HOST = '127.0.0.1';
 export const DEFAULT_DAEMON_BASE_URL = `http://${DEFAULT_DAEMON_HOST}:${DEFAULT_DAEMON_PORT}`;
 
 // 保持向后兼容的导出

--- a/packages/extension/src/options.ts
+++ b/packages/extension/src/options.ts
@@ -1,5 +1,5 @@
 const STORAGE_KEY = 'upstreamUrl';
-const DEFAULT_URL = 'http://localhost:19824';
+const DEFAULT_URL = 'http://127.0.0.1:19824';
 
 const urlInput = document.getElementById('url') as HTMLInputElement;
 const saveBtn = document.getElementById('save') as HTMLButtonElement;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -6,7 +6,7 @@
 export const DAEMON_PORT = 19824;
 
 /** Daemon 主机地址 */
-export const DAEMON_HOST = "localhost";
+export const DAEMON_HOST = "127.0.0.1";
 
 /** Daemon 基础 URL */
 export const DAEMON_BASE_URL = `http://${DAEMON_HOST}:${DAEMON_PORT}`;


### PR DESCRIPTION
## Summary

This PR fixes two daemon-related issues:

1. Align the default daemon host to `127.0.0.1`
2. Restore the `bb-browser daemon` CLI command

## Background

On macOS, binding the daemon to `localhost` may resolve to `::1`, while the CLI client connects to `127.0.0.1`. This can cause false negatives such as:

- `Daemon did not start in time`
- `Daemon not running`

 even when the daemon is actually up.

At the same time, `bb-browser daemon ...` was incorrectly routed through the `close` command in the CLI switch, so documented usage like:

```bash
bb-browser daemon --host 127.0.0.1
```

did not actually start the daemon as expected.

## Changes

- Change default daemon host from `localhost` to `127.0.0.1`
  - `packages/shared/src/constants.ts`
  - extension defaults / UI text
  - README docs
- Fix CLI routing for `bb-browser daemon`
  - support foreground daemon execution
  - support `bb-browser daemon status`
  - support `bb-browser daemon stop`

## Result

After this change:

```bash
bb-browser daemon --host 127.0.0.1
bb-browser status
bb-browser site twitter/bookmarks --count 1
```

works correctly in local verification, and the daemon consistently listens on IPv4 loopback by default.