### PR TITLE
fix(daemon): Chrome 146+ CDP compatibility

### DIFF
--- a/packages/daemon/src/cdp-connection.ts
+++ b/packages/daemon/src/cdp-connection.ts
@@ -7,8 +7,10 @@
  * cli/cdp-monitor.ts (persistent connection + event listening).
  */
 
+import { readFileSync } from "node:fs";
 import { request as httpRequest } from "node:http";
 import WebSocket from "ws";
+import { getDevToolsActivePortPath } from "@bb-browser/shared";
 import { TabStateManager } from "./tab-state.js";
 
 // ---------------------------------------------------------------------------
@@ -59,10 +61,33 @@ function fetchJson(url: string): Promise<unknown> {
 
 function connectWebSocket(url: string): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(url);
+    // Pass empty headers to prevent ws from sending an Origin header.
+    // Chrome 146+ rejects CDP WebSocket connections with a non-empty Origin (403).
+    const ws = new WebSocket(url, { headers: {} });
     ws.once("open", () => resolve(ws));
     ws.once("error", reject);
   });
+}
+
+/**
+ * Read Chrome's DevToolsActivePort file to discover the CDP WebSocket URL.
+ * Chrome writes this file to its user-data-dir on startup; it contains the
+ * debug port on the first line and the browser WebSocket path on the second.
+ */
+function readDevToolsActivePort(): string | undefined {
+  const portFile = getDevToolsActivePortPath();
+  try {
+    const lines = readFileSync(portFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    if (lines.length >= 2) {
+      const port = parseInt(lines[0], 10);
+      if (port > 0) return `ws://127.0.0.1:${port}${lines[1]}`;
+    }
+  } catch {}
+  return undefined;
 }
 
 function normalizeHeaders(headers: unknown): Record<string, string> | undefined {
@@ -130,12 +155,31 @@ export class CdpConnection {
   }
 
   private async doConnect(): Promise<void> {
-    const versionData = (await fetchJson(
-      `http://${this.host}:${this.port}/json/version`,
-    )) as JsonObject;
-    const wsUrl = versionData.webSocketDebuggerUrl;
+    let wsUrl: string | undefined;
+
+    // Primary: discover via /json/version HTTP endpoint
+    try {
+      const versionData = (await fetchJson(
+        `http://${this.host}:${this.port}/json/version`,
+      )) as JsonObject;
+      if (typeof versionData.webSocketDebuggerUrl === "string") {
+        wsUrl = versionData.webSocketDebuggerUrl;
+      }
+    } catch {}
+
+    // Fallback: read Chrome's DevToolsActivePort file.
+    // When Chrome is launched with --remote-debugging-port=0 or the /json/version
+    // endpoint is unreachable, Chrome writes the actual port and WebSocket path
+    // to this file.
+    if (!wsUrl) {
+      wsUrl = readDevToolsActivePort();
+    }
+
     if (typeof wsUrl !== "string" || !wsUrl) {
-      throw new Error("CDP endpoint missing webSocketDebuggerUrl");
+      throw new Error(
+        "Cannot discover Chrome CDP endpoint. Ensure Chrome is running with " +
+        "--remote-debugging-port or that /json/version is reachable.",
+      );
     }
 
     const ws = await connectWebSocket(wsUrl);

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -15,7 +15,7 @@ import { mkdirSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
-import { DAEMON_PORT, DAEMON_HOST } from "@bb-browser/shared";
+import { DAEMON_PORT, DAEMON_HOST, getDevToolsActivePortPath } from "@bb-browser/shared";
 import { HttpServer } from "./http-server.js";
 import { CdpConnection } from "./cdp-connection.js";
 import { TabStateManager } from "./tab-state.js";
@@ -174,6 +174,33 @@ async function discoverCdpPort(host: string, port: number): Promise<{ host: stri
           });
           if (response.ok) {
             return { host: "127.0.0.1", port: managedPort };
+          }
+        } finally {
+          clearTimeout(timer);
+        }
+      } catch {}
+    }
+  } catch {}
+
+  // Fallback: read Chrome's DevToolsActivePort file
+  const portFile = getDevToolsActivePortPath();
+  try {
+    const lines = readFileSync(portFile, "utf8")
+      .trim()
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+    const activePort = parseInt(lines[0], 10);
+    if (activePort > 0) {
+      try {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 2000);
+        try {
+          const response = await fetch(`http://127.0.0.1:${activePort}/json/version`, {
+            signal: controller.signal,
+          });
+          if (response.ok) {
+            return { host: "127.0.0.1", port: activePort };
           }
         } finally {
           clearTimeout(timer);

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -2,6 +2,9 @@
  * bb-browser 共享常量
  */
 
+import os from "node:os";
+import path from "node:path";
+
 /** Daemon HTTP 服务端口 */
 export const DAEMON_PORT = 19824;
 
@@ -10,6 +13,22 @@ export const DAEMON_HOST = "127.0.0.1";
 
 /** Daemon 基础 URL */
 export const DAEMON_BASE_URL = `http://${DAEMON_HOST}:${DAEMON_PORT}`;
+
+/**
+ * Platform-specific path to Chrome's DevToolsActivePort file.
+ * Chrome writes the debugging port and WebSocket path to this file on startup.
+ */
+export function getDevToolsActivePortPath(): string {
+  const h = os.homedir();
+  switch (process.platform) {
+    case "darwin":
+      return path.join(h, "Library/Application Support/Google/Chrome/DevToolsActivePort");
+    case "win32":
+      return path.join(process.env.LOCALAPPDATA || "", "Google/Chrome/User Data/DevToolsActivePort");
+    default:
+      return path.join(h, ".config/google-chrome/DevToolsActivePort");
+  }
+}
 
 /** SSE 心跳间隔（毫秒） - 15秒确保 MV3 Service Worker 不休眠 */
 export const SSE_HEARTBEAT_INTERVAL = 15000; // 15 秒

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,4 +28,5 @@ export {
   SSE_HEARTBEAT_INTERVAL,
   SSE_MAX_RECONNECT_ATTEMPTS,
   SSE_RECONNECT_DELAY,
+  getDevToolsActivePortPath,
 } from "./constants.js";


### PR DESCRIPTION
## Summary

Fixes two Chrome 146 breaking changes that prevent bb-browser from connecting to Chrome's CDP endpoint:

- **WebSocket Origin header 403**: Chrome 146 rejects CDP WebSocket connections that include an `Origin` header. This PR passes empty headers to the `ws` constructor to suppress it.
- **DevToolsActivePort fallback**: When `/json/version` is unreachable (e.g. Chrome launched with `--remote-debugging-port=0`), falls back to reading Chrome's `DevToolsActivePort` file for port and WebSocket path discovery. Applied to both `CdpConnection.doConnect()` and the daemon's `discoverCdpPort()`.

## Changes

- `packages/daemon/src/cdp-connection.ts`: `connectWebSocket()` now passes `{ headers: {} }` to suppress Origin; `doConnect()` falls back to `DevToolsActivePort`; added `readDevToolsActivePort()` helper.
- `packages/daemon/src/index.ts`: `discoverCdpPort()` adds `DevToolsActivePort` as a third fallback after the managed browser port file.

## Test plan

- [x] Tested on macOS with Chrome 146.0.6924.1 — `browser_tab_list` and `browser_screenshot` work correctly
- [ ] Linux / Windows path coverage (code handles all three platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)