### PR TITLE
fix(mcp): use daemon.json for daemon auth and endpoint

### DIFF
--- a/packages/mcp/src/daemon-client.test.ts
+++ b/packages/mcp/src/daemon-client.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { daemonBaseUrl, mergeDaemonHeaders } from "./daemon-client.js";
+
+test("daemonBaseUrl normalizes localhost to 127.0.0.1", () => {
+  assert.equal(
+    daemonBaseUrl({ host: "localhost", port: 19824 }),
+    "http://127.0.0.1:19824",
+  );
+});
+
+test("daemonBaseUrl preserves explicit hosts", () => {
+  assert.equal(
+    daemonBaseUrl({ host: "127.0.0.1", port: 24446 }),
+    "http://127.0.0.1:24446",
+  );
+});
+
+test("mergeDaemonHeaders injects bearer auth while preserving headers", () => {
+  assert.deepEqual(
+    mergeDaemonHeaders({ "Content-Type": "application/json" }, "token-123"),
+    {
+      "Content-Type": "application/json",
+      Authorization: "Bearer token-123",
+    },
+  );
+});

--- a/packages/mcp/src/daemon-client.ts
+++ b/packages/mcp/src/daemon-client.ts
@@ -1,0 +1,209 @@
+import { spawn } from "node:child_process";
+import { readFile, unlink } from "node:fs/promises";
+import { request as httpRequest } from "node:http";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Request as DaemonRequest, Response as DaemonResponse } from "@bb-browser/shared";
+
+const DAEMON_DIR = path.join(os.homedir(), ".bb-browser");
+const DAEMON_JSON = path.join(DAEMON_DIR, "daemon.json");
+const COMMAND_TIMEOUT = 30000;
+
+export interface DaemonInfo {
+  pid: number;
+  host: string;
+  port: number;
+  token: string;
+}
+
+let cachedInfo: DaemonInfo | null = null;
+let daemonReady = false;
+
+export function normalizeDaemonHost(host: string): string {
+  return host === "localhost" ? "127.0.0.1" : host;
+}
+
+export function daemonBaseUrl(info: Pick<DaemonInfo, "host" | "port">): string {
+  return `http://${normalizeDaemonHost(info.host)}:${info.port}`;
+}
+
+export function mergeDaemonHeaders(headers: Record<string, string>, token: string): Record<string, string> {
+  return {
+    ...headers,
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function httpJson<T>(
+  method: "GET" | "POST",
+  urlPath: string,
+  info: Pick<DaemonInfo, "host" | "port" | "token">,
+  body?: unknown,
+  timeout = 5000,
+): Promise<T> {
+  return new Promise((resolvePromise, reject) => {
+    const payload = body !== undefined ? JSON.stringify(body) : undefined;
+    const req = httpRequest(
+      {
+        hostname: normalizeDaemonHost(info.host),
+        port: info.port,
+        path: urlPath,
+        method,
+        headers: mergeDaemonHeaders(
+          payload
+            ? {
+                "Content-Type": "application/json",
+                "Content-Length": String(Buffer.byteLength(payload)),
+              }
+            : {},
+          info.token,
+        ),
+        timeout,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+        res.on("end", () => {
+          const raw = Buffer.concat(chunks).toString("utf8");
+          if ((res.statusCode ?? 500) >= 400) {
+            reject(new Error(`Daemon HTTP ${res.statusCode}: ${raw}`));
+            return;
+          }
+          try {
+            resolvePromise(JSON.parse(raw) as T);
+          } catch {
+            reject(new Error(`Invalid JSON from daemon: ${raw}`));
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("Daemon request timed out"));
+    });
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+async function readDaemonJson(): Promise<DaemonInfo | null> {
+  try {
+    const raw = await readFile(DAEMON_JSON, "utf8");
+    const info = JSON.parse(raw) as DaemonInfo;
+    if (
+      typeof info.pid === "number" &&
+      typeof info.host === "string" &&
+      typeof info.port === "number" &&
+      typeof info.token === "string"
+    ) {
+      return info;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function deleteDaemonJson(): Promise<void> {
+  try {
+    await unlink(DAEMON_JSON);
+  } catch {}
+}
+
+export function getDaemonPath(): string {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  const sameDirPath = resolve(currentDir, "daemon.js");
+  if (existsSync(sameDirPath)) return sameDirPath;
+  return resolve(currentDir, "../../daemon/dist/index.js");
+}
+
+export async function isDaemonRunning(): Promise<boolean> {
+  const info = cachedInfo ?? (await readDaemonJson());
+  if (!info) return false;
+  try {
+    const status = await httpJson<{ running?: boolean }>("GET", "/status", info, undefined, 2000);
+    return status.running === true;
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureDaemon(): Promise<void> {
+  if (daemonReady && cachedInfo) {
+    try {
+      await httpJson<{ running?: boolean }>("GET", "/status", cachedInfo, undefined, 2000);
+      return;
+    } catch {
+      daemonReady = false;
+      cachedInfo = null;
+    }
+  }
+
+  let info = await readDaemonJson();
+  if (info) {
+    if (!isProcessAlive(info.pid)) {
+      await deleteDaemonJson();
+      info = null;
+    } else {
+      try {
+        const status = await httpJson<{ running?: boolean }>("GET", "/status", info, undefined, 2000);
+        if (status.running) {
+          cachedInfo = info;
+          daemonReady = true;
+          return;
+        }
+      } catch {
+        cachedInfo = null;
+      }
+    }
+  }
+
+  const child = spawn(process.execPath, [getDaemonPath()], {
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env },
+  });
+  child.unref();
+
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 200));
+    info = await readDaemonJson();
+    if (!info) continue;
+    try {
+      const status = await httpJson<{ running?: boolean }>("GET", "/status", info, undefined, 2000);
+      if (status.running) {
+        cachedInfo = info;
+        daemonReady = true;
+        return;
+      }
+    } catch {}
+  }
+
+  throw new Error(
+    "bb-browser: Daemon did not start in time.\n\nMake sure Chrome is installed, then try again.",
+  );
+}
+
+export async function daemonCommand(request: DaemonRequest): Promise<DaemonResponse> {
+  if (!cachedInfo) {
+    cachedInfo = await readDaemonJson();
+  }
+  if (!cachedInfo) {
+    throw new Error("No daemon.json found. Is the daemon running?");
+  }
+  return httpJson<DaemonResponse>("POST", "/command", cachedInfo, request, COMMAND_TIMEOUT);
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,12 +1,13 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { DAEMON_BASE_URL, COMMAND_TIMEOUT, generateId } from "@bb-browser/shared";
+import { COMMAND_TIMEOUT, generateId } from "@bb-browser/shared";
 import type { Request, Response } from "@bb-browser/shared";
-import { execFile, spawn } from "node:child_process";
+import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { z } from "zod";
+import { daemonCommand, ensureDaemon } from "./daemon-client.js";
 
 declare const __BB_BROWSER_VERSION__: string;
 
@@ -19,13 +20,6 @@ const CHROME_NOT_CONNECTED_HINT = [
 
 const sessionOpenedTabs = new Set<string>();
 
-function getDaemonPath(): string {
-  const currentDir = dirname(fileURLToPath(import.meta.url));
-  const sameDirPath = resolve(currentDir, "daemon.js");
-  if (existsSync(sameDirPath)) return sameDirPath;
-  return resolve(currentDir, "../../daemon/dist/index.js");
-}
-
 function getCliPath(): string {
   const currentDir = dirname(fileURLToPath(import.meta.url));
   const sameDirPath = resolve(currentDir, "cli.js");
@@ -33,48 +27,16 @@ function getCliPath(): string {
   return resolve(currentDir, "../../cli/dist/index.js");
 }
 
-async function isDaemonRunning(): Promise<boolean> {
-  try {
-    const controller = new AbortController();
-    const t = setTimeout(() => controller.abort(), 2000);
-    const res = await fetch(`${DAEMON_BASE_URL}/status`, { signal: controller.signal });
-    clearTimeout(t);
-    return res.ok;
-  } catch { return false; }
-}
-
-async function ensureDaemon(): Promise<void> {
-  if (await isDaemonRunning()) return;
-  const child = spawn(process.execPath, [getDaemonPath()], {
-    detached: true, stdio: "ignore", env: { ...process.env },
-  });
-  child.unref();
-  // wait up to 5s
-  for (let i = 0; i < 25; i++) {
-    await new Promise(r => setTimeout(r, 200));
-    if (await isDaemonRunning()) return;
-  }
-}
-
 async function sendCommand(request: Request): Promise<Response> {
-  await ensureDaemon();
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), COMMAND_TIMEOUT);
   try {
-    const response = await fetch(`${DAEMON_BASE_URL}/command`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(request),
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
-    if (response.status === 503) {
+    await ensureDaemon();
+    return await daemonCommand(request);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes("Daemon HTTP 503")) {
       return { id: request.id, success: false, error: CHROME_NOT_CONNECTED_HINT };
     }
-    return (await response.json()) as Response;
-  } catch {
-    clearTimeout(timeoutId);
-    return { id: request.id, success: false, error: "Failed to start daemon. Run manually: bb-browser daemon" };
+    return { id: request.id, success: false, error: message || "Failed to start daemon. Run manually: bb-browser daemon" };
   }
 }
 


### PR DESCRIPTION
## Summary

The MCP entrypoint still talks to the daemon using a hardcoded unauthenticated `DAEMON_BASE_URL`, while the CLI has already moved to `~/.bb-browser/daemon.json`.

This causes two real problems:

1. MCP requests can fail with `Unauthorized` because the daemon expects a Bearer token.
2. MCP can miss the daemon when the actual listener differs from the hardcoded base URL assumptions.

This PR aligns MCP with the daemon discovery/auth model already used by the CLI.

## Changes

- add `packages/mcp/src/daemon-client.ts`
  - read `~/.bb-browser/daemon.json`
  - normalize `localhost` to `127.0.0.1` for HTTP requests
  - include daemon Bearer auth headers
  - detect stale daemon metadata via PID liveness checks
  - spawn and wait for the daemon when needed
- update `packages/mcp/src/index.ts`
  - route MCP command traffic through the new daemon client
  - preserve the existing friendly `Chrome is not connected...` hint for daemon `503` responses
- add `packages/mcp/src/daemon-client.test.ts`
  - cover daemon base URL normalization
  - cover Bearer header injection

## Why this is safe

- scope is limited to MCP daemon communication
- CLI behavior is unchanged
- existing MCP command routing and response formatting remain intact
- the new code follows the same `daemon.json` contract already present in `packages/cli/src/daemon-manager.ts`

## Verification

Ran locally:

```bash
npx -y pnpm@9.15.0 exec tsx --test packages/mcp/src/daemon-client.test.ts
npx -y pnpm@9.15.0 --filter @bb-browser/shared build
npx -y pnpm@9.15.0 --filter @bb-browser/mcp build
```

This addresses the MCP-side daemon auth/endpoint mismatch. Related context: #141.
