### PR TITLE
fix(cli): forward --port and --host to daemon auto-spawn

### DIFF
--- a/packages/cli/src/daemon-manager.ts
+++ b/packages/cli/src/daemon-manager.ts
@@ -33,6 +33,18 @@ interface DaemonInfo {
 
 let cachedInfo: DaemonInfo | null = null;
 let daemonReady = false;
+let _spawnCdpPort: number | undefined;
+let _spawnHost: string | undefined;
+
+/**
+ * Configure CDP port and host for daemon auto-spawn.
+ * When ensureDaemon() needs to start a new daemon process,
+ * these values are forwarded as --cdp-port and --host arguments.
+ */
+export function setDaemonSpawnOptions(options: { cdpPort?: number; host?: string }): void {
+  _spawnCdpPort = options.cdpPort;
+  _spawnHost = options.host;
+}
 
 // ---------------------------------------------------------------------------
 // PID liveness check
@@ -193,7 +205,10 @@ export async function ensureDaemon(): Promise<void> {
 
   // Spawn daemon process
   const daemonPath = getDaemonPath();
-  const child = spawn(process.execPath, [daemonPath], {
+  const daemonArgs = [daemonPath];
+  if (_spawnCdpPort) daemonArgs.push("--cdp-port", String(_spawnCdpPort));
+  if (_spawnHost) daemonArgs.push("--host", String(_spawnHost));
+  const child = spawn(process.execPath, daemonArgs, {
     detached: true,
     stdio: "ignore",
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,7 +30,7 @@ import { fetchCommand } from "./commands/fetch.js";
 import { siteCommand } from "./commands/site.js";
 import { historyCommand } from "./commands/history.js";
 import { shutdownCommand, statusCommand } from "./commands/daemon.js";
-import { getDaemonPath } from "./daemon-manager.js";
+import { getDaemonPath, setDaemonSpawnOptions } from "./daemon-manager.js";
 import { setJqExpression } from "./client.js";
 
 declare const __BB_BROWSER_VERSION__: string;
@@ -96,6 +96,7 @@ bb-browser - AI Agent 浏览器自动化工具
 选项：
   --json               以 JSON 格式输出
   --port <n>           指定 Chrome CDP 端口
+  --host <addr>        指定 daemon 绑定地址（默认自动检测，macOS 建议 127.0.0.1）
   --openclaw           优先复用 OpenClaw 浏览器实例
   --jq <expr>          对 JSON 输出应用 jq 过滤（直接作用于数据，跳过 id/success 信封）
   -i, --interactive    只输出可交互元素（snapshot 命令）
@@ -124,6 +125,7 @@ interface ParsedArgs {
     jq?: string;
     openclaw?: boolean;
     port?: number;
+    host?: string;
     since?: string;
   };
 }
@@ -168,6 +170,12 @@ function parseArgs(argv: string[]): ParsedArgs {
       const nextIdx = args.indexOf(arg) + 1;
       if (nextIdx < args.length) {
         result.flags.port = parseInt(args[nextIdx], 10);
+      }
+    } else if (arg === "--host") {
+      skipNext = true;
+      const nextIdx = args.indexOf(arg) + 1;
+      if (nextIdx < args.length) {
+        result.flags.host = args[nextIdx];
       }
     } else if (arg === "--help" || arg === "-h") {
       result.flags.help = true;
@@ -228,6 +236,14 @@ function parseArgs(argv: string[]): ParsedArgs {
 async function main(): Promise<void> {
   const parsed = parseArgs(process.argv);
   setJqExpression(parsed.flags.jq);
+
+  // Forward --port / --host to daemon auto-spawn
+  if (parsed.flags.port || parsed.flags.host) {
+    setDaemonSpawnOptions({
+      cdpPort: parsed.flags.port,
+      host: parsed.flags.host,
+    });
+  }
 
   // 解析全局 --tab 参数
   const tabArgIdx = process.argv.indexOf('--tab');


### PR DESCRIPTION
## Summary

- When `ensureDaemon()` spawns a new daemon process, CLI flags `--port` and `--host` were silently dropped — the daemon always started with the default CDP port (19825)
- This meant `bb-browser --port 9222 tab list` would fail with "Daemon did not start in time" if Chrome was on port 9222
- Added `setDaemonSpawnOptions()` in daemon-manager to forward `--cdp-port` and `--host` to the detached daemon process
- Added `--host` flag parsing in CLI (was only accepted by daemon.js directly)

## Reproduction

```bash
# Chrome running with --remote-debugging-port=9222
bb-browser --port 9222 tab list
# Before: "Daemon did not start in time"
# After: works, daemon auto-spawns targeting port 9222
```

## Changes

- `packages/cli/src/daemon-manager.ts`: module-level spawn config + forward args in `ensureDaemon()`
- `packages/cli/src/index.ts`: parse `--host` flag, call `setDaemonSpawnOptions()` before command dispatch, update help text

## Test plan

- [ ] `bb-browser --port <custom> tab list` auto-spawns daemon on correct CDP port
- [ ] `bb-browser --port <custom> --host 127.0.0.1 snapshot` works on macOS (IPv6 workaround)
- [ ] Without `--port`, default behavior unchanged (daemon targets 19825)
- [ ] `bb-browser daemon --cdp-port <custom> --host 127.0.0.1` foreground mode still works