### PR TITLE
chore: configure release-please for pre-1.0 versioning

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
   "packages": {
     ".": {
       "release-type": "node"


### PR DESCRIPTION
## Summary

Prevent release-please from bumping to 1.0.0 on breaking changes while still in 0.x.

- `bump-minor-pre-major: true` — breaking changes bump minor (0.11 → 0.12) not major
- `bump-patch-for-minor-pre-major: true` — features bump patch (0.11.0 → 0.11.1) not minor

After merging, the existing release PR #135 should regenerate as `0.12.0` instead of `1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)