### PR TITLE
chore: force release as 0.11.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
   "bump-patch-for-minor-pre-major": true,
   "packages": {
     ".": {
-      "release-type": "node"
+      "release-type": "node",
+      "release-as": "0.11.1"
     }
   }
 }


### PR DESCRIPTION
Release-as override: 0.11.1

Breaking changes (Extension removal) were already shipped in 0.11.0.
This release is bug fixes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)