### PR TITLE
fix: remove extension packaging from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,16 +41,6 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Package extension
-        run: |
-          cd extension
-          zip -r "../bb-browser-extension-${{ inputs.tag_name }}.zip" .
-
-      - name: Upload extension asset
-        run: gh release upload "${{ inputs.tag_name }}" "bb-browser-extension-${{ inputs.tag_name }}.zip" --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Publish to npm
         run: pnpm publish --no-git-checks
         env:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
   "bump-patch-for-minor-pre-major": true,
   "packages": {
     ".": {
-      "release-type": "node",
-      "release-as": "0.11.1"
+      "release-type": "node"
     }
   }
 }


### PR DESCRIPTION
## Summary

Publish workflow fails because it tries to package the deleted `extension/` directory.

- Remove extension zip + upload steps from publish.yml
- Remove one-time `release-as: 0.11.1` override from release-please config

After merging, manually re-trigger the publish workflow for `bb-browser-v0.11.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)