### PR TITLE
fix: CDP 503 returns diagnostics immediately instead of 30s timeout

### DIFF
--- a/packages/cli/src/__tests__/daemon-startup.test.ts
+++ b/packages/cli/src/__tests__/daemon-startup.test.ts
@@ -349,3 +349,78 @@ describe("core bug: daemon spawned without --cdp-port fails silently (#136)", ()
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// Test: 503 error includes diagnostics
+// ---------------------------------------------------------------------------
+
+describe("CDP 503 error includes diagnostics", () => {
+  let daemonPid: number | null = null;
+
+  afterEach(async () => {
+    if (daemonPid && isProcessAlive(daemonPid)) {
+      killProcess(daemonPid);
+      await new Promise(r => setTimeout(r, 500));
+    }
+    daemonPid = null;
+    cleanupDaemonJson();
+  });
+
+  it("503 response includes CDP target, reason, and hint — responds immediately not 30s", async () => {
+    const cdpPort = 39989;
+    const daemonPort = 39988;
+    const fakeCdp = await startFakeCdpServer(cdpPort);
+
+    try {
+      const child = spawn(TSX, [DAEMON_ENTRY, "--cdp-port", String(cdpPort), "--port", String(daemonPort)], {
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+
+      const info = await waitForDaemonJson();
+      daemonPid = info.pid;
+
+      // Wait for daemon to try and fail CDP WebSocket
+      await new Promise(r => setTimeout(r, 2000));
+
+      const start = Date.now();
+      const response = await new Promise<Record<string, unknown>>((resolve, reject) => {
+        const req = http.request({
+          hostname: info.host,
+          port: info.port,
+          path: "/command",
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${info.token}`,
+            "Content-Type": "application/json",
+          },
+          timeout: 10000,
+        }, res => {
+          const chunks: Buffer[] = [];
+          res.on("data", (c: Buffer) => chunks.push(c));
+          res.on("end", () => {
+            try { resolve(JSON.parse(Buffer.concat(chunks).toString())); }
+            catch (e) { reject(e); }
+          });
+        });
+        req.on("error", reject);
+        req.write(JSON.stringify({ id: "diag-test", action: "tab_list" }));
+        req.end();
+      });
+      const elapsed = Date.now() - start;
+
+      // Must not wait 30s
+      assert.ok(elapsed < 10000, `should respond quickly, not wait 30s (took ${elapsed}ms)`);
+
+      // Must have diagnostics
+      assert.equal(response.success, false);
+      assert.match(response.error as string, /Chrome not connected/, "error should mention Chrome");
+      assert.ok(typeof response.reason === "string", "should include reason");
+      assert.ok((response.reason as string).length > 0, "reason should not be empty");
+      assert.ok(typeof response.hint === "string", "should include hint");
+    } finally {
+      await new Promise<void>(resolve => fakeCdp.close(() => resolve()));
+    }
+  });
+});

--- a/packages/daemon/src/cdp-connection.ts
+++ b/packages/daemon/src/cdp-connection.ts
@@ -96,6 +96,9 @@ export class CdpConnection {
   private connectionPromise: Promise<void> | null = null;
   private _connected = false;
 
+  /** Last connection error (for diagnostics in 503 responses). */
+  lastError: string | null = null;
+
   /** Resolvers for commands queued before CDP is ready. */
   private readyWaiters: Array<{ resolve: () => void; reject: (err: Error) => void }> = [];
 
@@ -124,6 +127,15 @@ export class CdpConnection {
     this.connectionPromise = this.doConnect();
     try {
       await this.connectionPromise;
+      this.lastError = null;
+    } catch (err) {
+      this.lastError = err instanceof Error ? err.message : String(err);
+      const connErr = new Error(this.lastError);
+      for (const waiter of this.readyWaiters) {
+        waiter.reject(connErr);
+      }
+      this.readyWaiters = [];
+      throw err;
     } finally {
       this.connectionPromise = null;
     }
@@ -164,6 +176,7 @@ export class CdpConnection {
   /** Wait until CDP connection is established (for two-phase startup). */
   waitUntilReady(): Promise<void> {
     if (this._connected) return Promise.resolve();
+    if (this.lastError) return Promise.reject(new Error(this.lastError));
     return new Promise<void>((resolve, reject) => {
       this.readyWaiters.push({ resolve, reject });
     });
@@ -284,10 +297,17 @@ export class CdpConnection {
     ws.on("close", () => {
       this._connected = false;
       this.socket = null;
+      this.lastError = "CDP WebSocket closed unexpectedly";
       for (const p of this.pending.values()) {
         p.reject(new Error("CDP connection closed"));
       }
       this.pending.clear();
+
+      const closeErr = new Error(this.lastError);
+      for (const waiter of this.readyWaiters) {
+        waiter.reject(closeErr);
+      }
+      this.readyWaiters = [];
     });
 
     ws.on("error", () => {});

--- a/packages/daemon/src/http-server.ts
+++ b/packages/daemon/src/http-server.ts
@@ -135,11 +135,15 @@ export class HttpServer {
               setTimeout(() => reject(new Error("CDP connection timeout")), COMMAND_TIMEOUT),
             ),
           ]);
-        } catch (error) {
+        } catch {
+          const cdpTarget = `${this.cdp.host}:${this.cdp.port}`;
+          const reason = this.cdp.lastError || "unknown";
           this.sendJson(res, 503, {
             id: request.id,
             success: false,
-            error: error instanceof Error ? error.message : "CDP not ready",
+            error: `Chrome not connected (CDP at ${cdpTarget})`,
+            reason,
+            hint: "Make sure Chrome is running. Try: bb-browser daemon shutdown && bb-browser tab list",
           });
           return;
         }


### PR DESCRIPTION
## Summary

When Chrome disconnects or CDP connection fails, daemon returned `{"error":"CDP connection timeout"}` after waiting **30 seconds**. Now returns immediately with diagnostics.

Chrome 断连时，daemon 原来要等 30 秒才返回 "CDP connection timeout"。现在立即返回，并带上具体的诊断信息。

**Before:**
```json
{"error":"CDP connection timeout"}  // 30s later
```

**After:**
```json
{
  "error": "Chrome not connected (CDP at 127.0.0.1:19825)",
  "reason": "Unexpected server response: 404",
  "hint": "Make sure Chrome is running. Try: bb-browser daemon shutdown && bb-browser tab list"
}  // immediate
```

## Changes

- `CdpConnection.lastError`: stores connection failure reason for diagnostic context
- `CdpConnection.waitUntilReady()`: rejects immediately if connection already failed (instead of pending forever)
- `CdpConnection` ws close handler: rejects pending waiters
- HTTP 503 response: includes `error` (with CDP target), `reason`, and `hint`
- New test: verifies 503 responds in <10s with all diagnostic fields

## Test plan

- [x] New test: "503 response includes CDP target, reason, and hint — responds immediately not 30s"
- [x] Manual verification: fake CDP → daemon → curl → immediate 503 with diagnostics
- [x] Full suite: 130 tests pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)