### PR TITLE
fix: bypass CORS for site adapters via about:blank execution

### DIFF
--- a/packages/cli/src/cdp-discovery.ts
+++ b/packages/cli/src/cdp-discovery.ts
@@ -175,6 +175,7 @@ export async function launchManagedBrowser(port: number = DEFAULT_CDP_PORT): Pro
     "--disable-background-networking",
     "--disable-component-update",
     "--disable-features=Translate,MediaRouter",
+    "--disable-web-security",
     "--disable-session-crashed-bubble",
     "--hide-crash-restore-bubble",
     "about:blank",

--- a/packages/cli/src/commands/site.ts
+++ b/packages/cli/src/commands/site.ts
@@ -648,8 +648,34 @@ async function siteRun(
   // 确定目标 tab
   let targetTabId: number | undefined = options.tabId;
 
-  // 如果用户没指定 --tab，自动查找匹配域名的 tab
-  if (!targetTabId && site.domain) {
+  // Adapters with "network" capability (and without "cookie") make cross-origin
+  // API calls that fail under page-context CORS. Execute them on an about:blank
+  // tab where the managed browser's --disable-web-security flag takes effect.
+  const hasNetworkCap = Array.isArray(site.capabilities) && site.capabilities.includes("network");
+  const hasCookieCap = Array.isArray(site.capabilities) && site.capabilities.includes("cookie");
+  const useBlankTab = hasNetworkCap && !hasCookieCap && !targetTabId;
+
+  if (useBlankTab) {
+    // Find or create an about:blank tab for CORS-free execution
+    const listReq: Request = { id: generateId(), action: "tab_list" };
+    const listResp: Response = await sendCommand(listReq);
+    if (listResp.success && listResp.data?.tabs) {
+      const blankTab = listResp.data.tabs.find((tab: TabInfo) => tab.url === "about:blank");
+      if (blankTab) {
+        targetTabId = blankTab.tabId;
+      }
+    }
+    if (!targetTabId) {
+      const newResp = await sendCommand({
+        id: generateId(),
+        action: "tab_new",
+        url: "about:blank",
+      });
+      targetTabId = newResp.data?.tabId;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  } else if (!targetTabId && site.domain) {
+    // 如果用户没指定 --tab，自动查找匹配域名的 tab
     const listReq: Request = { id: generateId(), action: "tab_list" };
     const listResp: Response = await sendCommand(listReq);
 
@@ -675,7 +701,29 @@ async function siteRun(
 
   // 执行
   const evalReq: Request = { id: generateId(), action: "eval", script, tabId: targetTabId };
-  const evalResp: Response = await sendCommand(evalReq);
+  let evalResp: Response = await sendCommand(evalReq);
+
+  // Fallback: if eval failed with "Failed to fetch" on a domain tab, retry on
+  // about:blank where --disable-web-security eliminates CORS restrictions.
+  // This catches adapters that lack capabilities: ["network"] but still make
+  // cross-origin API calls.
+  if (!evalResp.success && /Failed to fetch/i.test(evalResp.error || "") && !useBlankTab) {
+    let blankTabId: string | undefined;
+    const listReq: Request = { id: generateId(), action: "tab_list" };
+    const listResp: Response = await sendCommand(listReq);
+    if (listResp.success && listResp.data?.tabs) {
+      const blankTab = listResp.data.tabs.find((tab: TabInfo) => tab.url === "about:blank");
+      if (blankTab) blankTabId = blankTab.tabId;
+    }
+    if (!blankTabId) {
+      const newResp = await sendCommand({ id: generateId(), action: "tab_new", url: "about:blank" });
+      blankTabId = newResp.data?.tabId;
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+    if (blankTabId) {
+      evalResp = await sendCommand({ id: generateId(), action: "eval", script, tabId: blankTabId });
+    }
+  }
 
   if (!evalResp.success) {
     const hint = site.domain


### PR DESCRIPTION
## Summary

Site adapters that make cross-origin API calls fail with `TypeError: Failed to fetch` because `Runtime.evaluate` runs in page context where browser CORS restrictions apply. This affects ~50% of adapters including `hackernews/top`, `bbc/news`, `arxiv/search`, `stackoverflow/search`, etc.

**Root cause:** After #132 removed the Extension and unified the daemon, the maintainer noted "CDP 层面处理了跨域 fetch", but `Runtime.evaluate` still executes JS in page context, which is subject to CORS. The issue was never actually fixed.

## Changes

Two files, two complementary fixes:

### 1. `cdp-discovery.ts` — Add `--disable-web-security` to managed browser (1 line)

The managed browser is a dedicated Chrome instance with its own `--user-data-dir`, completely isolated from the user's daily browser. Adding `--disable-web-security` eliminates CORS enforcement on `about:blank` tabs (null origin), enabling cross-origin `fetch()` calls.

### 2. `site.ts` — Smart tab routing for adapters (51 lines)

- **Primary path:** Adapters with `capabilities: ["network"]` (and without `"cookie"`) are routed to an `about:blank` tab instead of the target domain tab. Combined with `--disable-web-security`, cross-origin fetch succeeds.
- **Fallback path:** If any adapter fails with `"Failed to fetch"` on a domain tab, automatically retry on `about:blank`. This catches adapters that make cross-origin calls but don't declare `capabilities: ["network"]` (e.g. `bbc/news`, `arxiv/search`).
- **Cookie-dependent adapters** (same-origin) continue to run on the domain tab as before — no behavior change.

## Why not the other approaches?

| Approach | Issue |
|----------|-------|
| PR #15 (`Page.setBypassCSP`) | Only bypasses CSP, not CORS. Also never restored, leaving user tabs permanently vulnerable |
| PR #45 (`new Function()` in Node) | `"network"` capability is ambiguous — some adapters declare it but depend on `document.cookie`. Also exposes `process`/`require`/`fs` to adapter code |
| This PR (`about:blank` + `--disable-web-security`) | Runs in browser sandbox (safe), no ambiguity (blank tab = no origin = no CORS), fallback catches unlabeled adapters |

## Test plan

Tested on macOS with Chrome 146 + bb-browser 0.11.2:

- [x] `bb-browser site hackernews/top 3` — ✅ (was: Failed to fetch)
- [x] `bb-browser site bbc/news` — ✅ (was: Failed to fetch)
- [x] `bb-browser site arxiv/search "LLM agent"` — ✅ (was: Failed to fetch)
- [x] `bb-browser site stackoverflow/search "async await"` — ✅ (was: Failed to fetch)
- [x] `bb-browser site wikipedia/summary "Python"` — ✅ (was: Failed to fetch)
- [x] `bb-browser eval "document.title"` — ✅ regression check
- [ ] `bb-browser site zhihu/hot` — needs login (expected, cookie-dependent adapter)

Fixes #41
Partially addresses #110 (cross-origin fetch portion)
Related: #104, #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)