### PR TITLE
fix: mcp daemon auth and stdio pipe

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -249,10 +249,9 @@ async function main(): Promise<void> {
 
   if (process.argv.includes("--mcp")) {
     const mcpPath = fileURLToPath(new URL("./mcp.js", import.meta.url));
-    const { spawn } = await import("node:child_process");
-    const child = spawn(process.execPath, [mcpPath], { stdio: "inherit" });
-    child.on("exit", (code) => process.exit(code ?? 0));
-    return;
+    const { spawnSync } = await import("node:child_process");
+    const result = spawnSync(process.execPath, [mcpPath], { stdio: "inherit" });
+    process.exit(result.status ?? 0);
   }
 
   if (!parsed.command) {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -3,10 +3,28 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { DAEMON_BASE_URL, COMMAND_TIMEOUT, generateId } from "@bb-browser/shared";
 import type { Request, Response } from "@bb-browser/shared";
 import { execFile, spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
+import { dirname, resolve, join } from "node:path";
+import { homedir } from "node:os";
 import { z } from "zod";
+
+const DAEMON_JSON = join(homedir(), ".bb-browser", "daemon.json");
+
+function getDaemonToken(): string | null {
+  try {
+    const data = JSON.parse(readFileSync(DAEMON_JSON, "utf8"));
+    return data.token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function authHeaders(): Record<string, string> {
+  const token = getDaemonToken();
+  if (!token) return {};
+  return { "Authorization": `Bearer ${token}` };
+}
 
 declare const __BB_BROWSER_VERSION__: string;
 
@@ -37,7 +55,10 @@ async function isDaemonRunning(): Promise<boolean> {
   try {
     const controller = new AbortController();
     const t = setTimeout(() => controller.abort(), 2000);
-    const res = await fetch(`${DAEMON_BASE_URL}/status`, { signal: controller.signal });
+    const res = await fetch(`${DAEMON_BASE_URL}/status`, {
+      headers: authHeaders(),
+      signal: controller.signal,
+    });
     clearTimeout(t);
     return res.ok;
   } catch { return false; }
@@ -88,7 +109,7 @@ async function sendCommand(request: Request): Promise<Response> {
   try {
     const response = await fetch(`${DAEMON_BASE_URL}/command`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...authHeaders() },
       body: JSON.stringify(request),
       signal: controller.signal,
     });


### PR DESCRIPTION
Two bugs when using `bb-browser --mcp` with a running daemon.

**1. MCP server ignores daemon auth token**

`sendCommand` and `isDaemonRunning` both make HTTP requests to the daemon without reading the token from `~/.bb-browser/daemon.json`. Daemon responds 401. Fixed by reading the token at call time and adding `Authorization: Bearer` to both fetch calls.

**2. `--mcp` stdio pipe breaks under some MCP clients**

`spawn` with `stdio: "inherit"` creates a grandchild process. MCP clients that connect to the spawned process lose the stdio channel when the parent (`cli.js`) exits. Changed to `spawnSync` so the CLI blocks until `mcp.js` finishes, keeping the pipe intact.

## Test plan
- [x] `bb-browser --mcp` connects successfully with daemon running (no 401)
- [x] Tools callable end-to-end via OpenCode MCP client
- [x] Full test suite: 130 pass, 0 fail