### PR TITLE
feat(click): add selector and coordinate click modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Six platforms, six dimensions, structured JSON. Faster and broader than any huma
 bb-browser open https://example.com
 bb-browser snapshot -i                # accessibility tree
 bb-browser click @3                   # click element
+bb-browser click --selector ".submit" # click by CSS selector
+bb-browser click --coord 320,200      # click by viewport coordinates
 bb-browser fill @5 "hello"            # fill input
 bb-browser eval "document.title"      # run JS
 bb-browser fetch URL --json           # authenticated fetch

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -146,6 +146,8 @@ bb-browser site 36kr/newsflash
 bb-browser open https://example.com
 bb-browser snapshot -i                # 可访问性树
 bb-browser click @3                   # 点击元素
+bb-browser click --selector ".submit" # 按 CSS 选择器点击
+bb-browser click --coord 320,200      # 按视口坐标点击
 bb-browser fill @5 "hello"            # 填写输入框
 bb-browser eval "document.title"      # 执行 JS
 bb-browser fetch URL --json           # 带登录态的 fetch

--- a/packages/cli/src/commands/click.ts
+++ b/packages/cli/src/commands/click.ts
@@ -1,6 +1,9 @@
 /**
  * click 命令 - 点击元素
- * 用法：bb-browser click <ref>
+ * 用法：
+ *   bb-browser click <ref>
+ *   bb-browser click --selector <css选择器>
+ *   bb-browser click --coord <x,y>
  * 
  * ref 支持格式：
  *   - "@5" 或 "5"：使用 snapshot 返回的 ref ID
@@ -13,6 +16,9 @@ import { ensureDaemonRunning } from "../daemon-manager.js";
 export interface ClickOptions {
   json?: boolean;
   tabId?: string | number;
+  ref?: string;
+  selector?: string;
+  coord?: string;
 }
 
 /**
@@ -24,27 +30,39 @@ function parseRef(ref: string): string {
 }
 
 export async function clickCommand(
-  ref: string,
   options: ClickOptions = {}
 ): Promise<void> {
-  // 验证 ref
-  if (!ref) {
-    throw new Error("缺少 ref 参数");
+  const { ref, selector, coord } = options;
+
+  // 验证
+  if (!coord && !selector && !ref) {
+    throw new Error("缺少参数：需要 ref、--selector 或 --coord");
   }
 
   // 确保 Daemon 运行
   await ensureDaemonRunning();
 
-  // 解析 ref
-  const parsedRef = parseRef(ref);
-
   // 构造请求
   const request: Request = {
     id: generateId(),
     action: "click",
-    ref: parsedRef,
     tabId: options.tabId,
   };
+
+  if (coord) {
+    const parts = coord.split(",");
+    const x = parseFloat(parts[0] ?? "");
+    const y = parseFloat(parts[1] ?? "");
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      throw new Error(`--coord 格式无效，应为 "x,y"，如 "320,200"`);
+    }
+    request.x = x;
+    request.y = y;
+  } else if (selector) {
+    request.selector = selector;
+  } else if (ref) {
+    request.ref = parseRef(ref);
+  }
 
   // 发送请求
   const response: Response = await sendCommand(request);
@@ -54,8 +72,8 @@ export async function clickCommand(
     console.log(JSON.stringify(response, null, 2));
   } else {
     if (response.success) {
-      const role = response.data?.role ?? "element";
-      const name = response.data?.name;
+      const role = (response.data as any)?.role ?? "element";
+      const name = (response.data as any)?.name;
       if (name) {
         console.log(`已点击: ${role} "${name}"`);
       } else {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -63,7 +63,7 @@ bb-browser - AI Agent 浏览器自动化工具
 浏览器操作：
   open <url> [--tab]           打开 URL
   snapshot [-i] [-c] [-d <n>]  获取页面快照
-  click <ref>                  点击元素
+  click [ref] [--selector|--coord] 点击元素
   hover <ref>                  悬停元素
   fill <ref> <text>            填充输入框（清空后填入）
   type <ref> <text>            逐字符输入（不清空）
@@ -101,7 +101,8 @@ bb-browser - AI Agent 浏览器自动化工具
   -i, --interactive    只输出可交互元素（snapshot 命令）
   -c, --compact        移除空结构节点（snapshot 命令）
   -d, --depth <n>      限制树深度（snapshot 命令）
-  -s, --selector <sel> 限定 CSS 选择器范围（snapshot 命令）
+  -s, --selector <sel> 限定 CSS 选择器范围（snapshot）或按选择器点击（click）
+  --coord <x,y>        按视口坐标点击元素（click 命令）
   --tab <tabId>        指定操作的标签页 ID
   --mcp                启动 MCP server（用于 Claude Code / Cursor 等 AI 工具）
   --help, -h           显示帮助信息
@@ -119,6 +120,7 @@ interface ParsedArgs {
     compact: boolean;
     depth?: number;
     selector?: string;
+    coord?: string;
     tab?: string;
     days?: number;
     jq?: string;
@@ -188,6 +190,12 @@ function parseArgs(argv: string[]): ParsedArgs {
       const nextIdx = args.indexOf(arg) + 1;
       if (nextIdx < args.length) {
         result.flags.selector = args[nextIdx];
+      }
+    } else if (arg === "--coord") {
+      skipNext = true;
+      const nextIdx = args.indexOf(arg) + 1;
+      if (nextIdx < args.length) {
+        result.flags.coord = args[nextIdx];
       }
     } else if (arg === "--days") {
       skipNext = true;
@@ -296,13 +304,17 @@ async function main(): Promise<void> {
 
       case "click": {
         const ref = parsed.args[0];
-        if (!ref) {
-          console.error("错误：缺少 ref 参数");
-          console.error("用法：bb-browser click <ref>");
+        const coord = parsed.flags.coord;
+        const selector = parsed.flags.selector;
+        if (!ref && !coord && !selector) {
+          console.error("错误：缺少参数：需要 ref、--selector 或 --coord");
+          console.error("用法：bb-browser click [ref] [--coord x,y] [--selector sel]");
           console.error("示例：bb-browser click @5");
+          console.error("      bb-browser click --coord 100,500");
+          console.error("      bb-browser click --selector \"button.submit\"");
           process.exit(1);
         }
-        await clickCommand(ref, { json: parsed.flags.json, tabId: globalTabId });
+        await clickCommand({ ref, coord, selector, json: parsed.flags.json, tabId: globalTabId });
         break;
       }
 

--- a/packages/daemon/src/command-dispatch.ts
+++ b/packages/daemon/src/command-dispatch.ts
@@ -622,10 +622,24 @@ export async function dispatchRequest(
     // -----------------------------------------------------------------------
     case "click":
     case "hover": {
-      if (!request.ref) return fail(request.id, "Missing ref parameter");
       const seq = tab.recordAction();
-      const backendNodeId = await parseRef(cdp, target.id, tab, request.ref);
-      const point = await getInteractablePoint(cdp, target.id, backendNodeId);
+      let point: { x: number; y: number };
+
+      if (request.x != null && request.y != null) {
+        point = { x: request.x, y: request.y };
+      } else if (request.selector) {
+        const doc = await cdp.sessionCommand<{ root: { nodeId: number } }>(target.id, "DOM.getDocument", {});
+        const node = await cdp.sessionCommand<{ nodeId: number }>(target.id, "DOM.querySelector", { nodeId: doc.root.nodeId, selector: request.selector });
+        if (!node.nodeId) return fail(request.id, `找不到元素: ${request.selector}`);
+        const desc = await cdp.sessionCommand<{ node: { backendNodeId: number } }>(target.id, "DOM.describeNode", { nodeId: node.nodeId });
+        point = await getInteractablePoint(cdp, target.id, desc.node.backendNodeId);
+      } else if (request.ref) {
+        const backendNodeId = await parseRef(cdp, target.id, tab, request.ref);
+        point = await getInteractablePoint(cdp, target.id, backendNodeId);
+      } else {
+        return fail(request.id, "Missing ref, selector, or coordinates");
+      }
+
       await cdp.sessionCommand(target.id, "Input.dispatchMouseEvent", {
         type: "mouseMoved", x: point.x, y: point.y, button: "none",
       });

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -68,8 +68,12 @@ export interface Request {
   index?: number;
   /** 标签页 ID（tab_select, tab_close 命令使用，优先于 index） */
   tabId?: number | string;
-  /** CSS 选择器（frame 命令使用，定位 iframe） */
+  /** CSS 选择器（frame 命令定位 iframe；click/hover 命令按选择器点击元素） */
   selector?: string;
+  /** 视口坐标 x（click/hover 命令，直接坐标点击） */
+  x?: number;
+  /** 视口坐标 y（click/hover 命令，直接坐标点击） */
+  y?: number;
   /** dialog 响应类型（dialog 命令使用） */
   dialogResponse?: "accept" | "dismiss";
   /** prompt 对话框的输入文本（dialog accept 时可选） */

--- a/skills/bb-browser/SKILL.md
+++ b/skills/bb-browser/SKILL.md
@@ -22,6 +22,8 @@ allowed-tools: Bash(bb-browser:*)
 bb-browser open <url>        # 打开页面（新 tab）
 bb-browser snapshot -i       # 获取可交互元素
 bb-browser click @5          # 点击元素
+bb-browser click --selector ".submit"  # 按 CSS 选择器点击
+bb-browser click --coord 320,200       # 按视口坐标点击
 bb-browser fill @3 "text"    # 填写输入框
 bb-browser close             # 完成后关闭 tab
 ```
@@ -129,6 +131,8 @@ bb-browser snapshot --json      # JSON 格式输出
 
 ```bash
 bb-browser click @5             # 点击
+bb-browser click --selector ".submit"  # 按 CSS 选择器点击
+bb-browser click --coord 320,200       # 按视口坐标点击
 bb-browser hover @5             # 悬停
 bb-browser fill @3 "text"       # 清空并填写
 bb-browser type @3 "text"       # 追加输入（不清空）
@@ -279,7 +283,7 @@ bb-browser eval "[...document.querySelectorAll('a')].map(a => a.href).join('\n')
 
 ### 操作页面元素（用 snapshot -i）
 
-当需要点击、填写、选择时，用 `snapshot -i` 获取可交互元素：
+当需要点击、填写、选择时，优先用 `snapshot -i` 获取可交互元素；如果已经知道精确选择器，或要点击固定坐标，也可以直接使用 `click --selector` / `click --coord`：
 
 ```bash
 bb-browser snapshot -i
@@ -290,6 +294,8 @@ bb-browser snapshot -i
 bb-browser fill @2 "username"
 bb-browser fill @3 "password"
 bb-browser click @1
+bb-browser click --selector "button[type=submit]"
+bb-browser click --coord 320,200
 ```
 
 `-i` 只显示可交互元素，过滤掉大量无关内容。


### PR DESCRIPTION
### Description
This PR enhances the `click` command by adding support for CSS selectors and coordinate-based clicking. 

Currently, the CLI's click command is limited to reference-based interaction. This update adds:
- `--selector` (alias `-s`): Allows clicking an element using a standard CSS selector.
- `--coord <x,y>`: Allows clicking at specific viewport coordinates.

### Why?
Sometimes elements are difficult to identify via the default snapshot reference (e.g., hidden layers or complex DOM structures). These additional modes provide more precision for browser automation.

### Test Result
Verified manually:
- `bb-browser click --selector ".play-button"` correctly triggers clicks.
- `bb-browser click --coord 600,400` correctly clicks at the specified location.
