### PR TITLE
feat(iframe): support auto-attached iframe network capture

### DIFF
--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -4,7 +4,8 @@
  * 用法：
  *   bb-browser open <url>                # 在新 tab 中打开
  *   bb-browser open <url> --tab current  # 在当前 tab 中打开
- *   bb-browser open <url> --tab 123      # 在指定 tabId 的 tab 中打开
+ *   bb-browser open <url> --tab 123      # 在指定数字 tab 索引中打开
+ *   bb-browser open <url> --tab c416     # 在指定短 tab ID 中打开
  */
 
 import { generateId, type Request, type Response } from "@bb-browser/shared";
@@ -14,7 +15,7 @@ import { getSiteHintForDomain } from "./site.js";
 
 export interface OpenOptions {
   json?: boolean;
-  tab?: string;  // "current" | tabId 数字字符串 | undefined（新建 tab）
+  tab?: string;  // "current" | short tab ID | numeric index string | undefined（新建 tab）
 }
 
 export async function openCommand(
@@ -48,12 +49,11 @@ export async function openCommand(
       // 使用当前活动 tab
       (request as Record<string, unknown>).tabId = "current";
     } else {
-      // 使用指定 tabId
-      const tabId = parseInt(options.tab, 10);
-      if (isNaN(tabId)) {
-        throw new Error(`无效的 tabId: ${options.tab}`);
-      }
-      (request as Record<string, unknown>).tabId = tabId;
+      // 使用指定 short tab ID 或数字索引
+      const tabRef = /^\d+$/.test(options.tab)
+        ? parseInt(options.tab, 10)
+        : options.tab;
+      (request as Record<string, unknown>).tabId = tabRef;
     }
   }
   // 不指定 --tab 时，tabId 为 undefined，扩展会创建新 tab

--- a/packages/daemon/src/__tests__/cdp-connection.test.ts
+++ b/packages/daemon/src/__tests__/cdp-connection.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { CdpConnection } from "../cdp-connection.js";
+import { TabStateManager } from "../tab-state.js";
+
+function makeConnection() {
+  const manager = new TabStateManager();
+  const cdp = new CdpConnection("127.0.0.1", 9222, manager);
+  return { cdp, manager };
+}
+
+describe("CdpConnection iframe target handling", () => {
+  it("maps auto-attached iframe targets to the owning page and enables network", async () => {
+    const { cdp, manager } = makeConnection();
+    manager.addTab("page-target");
+    (cdp as any).ownerPageTargetByTarget.set("page-target", "page-target");
+
+    const calls: Array<{ targetId: string; method: string }> = [];
+    (cdp as any).sessionCommand = async (targetId: string, method: string) => {
+      calls.push({ targetId, method });
+      return {};
+    };
+
+    await (cdp as any).handleSessionEvent("page-target", {
+      method: "Target.attachedToTarget",
+      params: {
+        sessionId: "iframe-session",
+        targetInfo: {
+          targetId: "iframe-target",
+          type: "iframe",
+        },
+      },
+    });
+
+    assert.equal((cdp as any).sessions.get("iframe-target"), "iframe-session");
+    assert.equal((cdp as any).attachedTargets.get("iframe-session"), "iframe-target");
+    assert.equal((cdp as any).ownerPageTargetByTarget.get("iframe-target"), "page-target");
+    assert.deepEqual(calls, [{ targetId: "iframe-target", method: "Network.enable" }]);
+  });
+
+  it("routes iframe network events into the owning page tab", async () => {
+    const { cdp, manager } = makeConnection();
+    const pageTab = manager.addTab("page-target");
+    (cdp as any).ownerPageTargetByTarget.set("page-target", "page-target");
+    (cdp as any).ownerPageTargetByTarget.set("iframe-target", "page-target");
+
+    await (cdp as any).handleSessionEvent("iframe-target", {
+      method: "Network.requestWillBeSent",
+      params: {
+        requestId: "req-1",
+        request: {
+          url: "https://example.com/api/data",
+          method: "GET",
+        },
+        type: "XHR",
+        timestamp: 1,
+      },
+    });
+
+    await (cdp as any).handleSessionEvent("iframe-target", {
+      method: "Network.responseReceived",
+      params: {
+        requestId: "req-1",
+        response: {
+          status: 200,
+          statusText: "OK",
+          headers: { "content-type": "application/json" },
+          mimeType: "application/json",
+        },
+      },
+    });
+
+    const { items } = pageTab.getNetworkRequests();
+    assert.equal(items.length, 1);
+    assert.equal(items[0].url, "https://example.com/api/data");
+    assert.equal(items[0].status, 200);
+    assert.equal(pageTab.getNetworkOriginTargetId(items[0].seq), "iframe-target");
+  });
+
+  it("cleans up iframe target ownership on detach", async () => {
+    const { cdp, manager } = makeConnection();
+    manager.addTab("page-target");
+    (cdp as any).ownerPageTargetByTarget.set("page-target", "page-target");
+    (cdp as any).ownerPageTargetByTarget.set("iframe-target", "page-target");
+    (cdp as any).sessions.set("iframe-target", "iframe-session");
+    (cdp as any).attachedTargets.set("iframe-session", "iframe-target");
+
+    await (cdp as any).handleSessionEvent("page-target", {
+      method: "Target.detachedFromTarget",
+      params: {
+        sessionId: "iframe-session",
+      },
+    });
+
+    assert.equal((cdp as any).sessions.get("iframe-target"), undefined);
+    assert.equal((cdp as any).attachedTargets.get("iframe-session"), undefined);
+    assert.equal((cdp as any).ownerPageTargetByTarget.get("iframe-target"), undefined);
+  });
+});

--- a/packages/daemon/src/__tests__/tab-state.test.ts
+++ b/packages/daemon/src/__tests__/tab-state.test.ts
@@ -165,6 +165,45 @@ describe("TabState", () => {
       const tab = makeTab(mgr);
       tab.updateNetworkFailure("unknown", "reason");
     });
+
+    it("keeps requests from different origin targets separate even when requestId matches", () => {
+      const mgr = makeManager();
+      const tab = makeTab(mgr);
+      tab.addNetworkRequest("shared-id", {
+        url: "https://main.example.com/api",
+        method: "GET",
+        type: "XHR",
+        timestamp: Date.now(),
+      }, "page-target");
+      tab.addNetworkRequest("shared-id", {
+        url: "https://iframe.example.com/api",
+        method: "GET",
+        type: "XHR",
+        timestamp: Date.now(),
+      }, "iframe-target");
+
+      tab.updateNetworkResponse("shared-id", { status: 200 }, "page-target");
+      tab.updateNetworkResponse("shared-id", { status: 204 }, "iframe-target");
+
+      const { items } = tab.getNetworkRequests();
+      assert.equal(items.length, 2);
+      assert.deepEqual(items.map((item) => item.status), [200, 204]);
+    });
+
+    it("tracks the origin target for each network entry", () => {
+      const mgr = makeManager();
+      const tab = makeTab(mgr);
+      tab.addNetworkRequest("iframe-req", {
+        url: "https://iframe.example.com/data",
+        method: "GET",
+        type: "XHR",
+        timestamp: Date.now(),
+      }, "iframe-target");
+
+      const { items } = tab.getNetworkRequests();
+      assert.equal(items.length, 1);
+      assert.equal(tab.getNetworkOriginTargetId(items[0].seq), "iframe-target");
+    });
   });
 
   describe("console events", () => {

--- a/packages/daemon/src/cdp-connection.ts
+++ b/packages/daemon/src/cdp-connection.ts
@@ -85,6 +85,8 @@ export class CdpConnection {
   private sessions = new Map<string, string>();
   /** sessionId -> targetId */
   private attachedTargets = new Map<string, string>();
+  /** targetId -> owning page targetId (page targets map to themselves) */
+  private ownerPageTargetByTarget = new Map<string, string>();
 
   readonly host: string;
   readonly port: number;
@@ -237,6 +239,9 @@ export class CdpConnection {
         if (typeof sessionId === "string" && typeof targetInfo?.targetId === "string") {
           this.sessions.set(targetInfo.targetId, sessionId);
           this.attachedTargets.set(sessionId, targetInfo.targetId);
+          if (targetInfo.type === "page") {
+            this.ownerPageTargetByTarget.set(targetInfo.targetId, targetInfo.targetId);
+          }
         }
         return;
       }
@@ -249,6 +254,7 @@ export class CdpConnection {
           if (targetId) {
             this.sessions.delete(targetId);
             this.attachedTargets.delete(sessionId);
+            this.ownerPageTargetByTarget.delete(targetId);
             this.tabManager.removeTab(targetId);
             if (this.currentTargetId === targetId) {
               this.currentTargetId = undefined;
@@ -277,6 +283,7 @@ export class CdpConnection {
             this.sessions.delete(targetId);
             this.attachedTargets.delete(sessionId);
           }
+          this.ownerPageTargetByTarget.delete(targetId);
           this.tabManager.removeTab(targetId);
           if (this.currentTargetId === targetId) {
             this.currentTargetId = undefined;
@@ -322,7 +329,39 @@ export class CdpConnection {
     const params = (event.params ?? {}) as JsonObject;
     if (typeof method !== "string") return;
 
-    const tab = this.tabManager.getTab(targetId);
+    if (method === "Target.attachedToTarget") {
+      const sessionId = params.sessionId;
+      const targetInfo = params.targetInfo as JsonObject;
+      if (typeof sessionId === "string" && typeof targetInfo?.targetId === "string") {
+        const ownerPageTargetId = this.getOwningPageTargetId(targetId);
+        this.sessions.set(targetInfo.targetId, sessionId);
+        this.attachedTargets.set(sessionId, targetInfo.targetId);
+        this.ownerPageTargetByTarget.set(targetInfo.targetId, ownerPageTargetId);
+        if (targetInfo.type === "iframe") {
+          await this.sessionCommand(targetInfo.targetId, "Network.enable").catch(() => {});
+        }
+      }
+      return;
+    }
+
+    if (method === "Target.detachedFromTarget") {
+      const sessionId = params.sessionId;
+      if (typeof sessionId === "string") {
+        const detachedTargetId = this.attachedTargets.get(sessionId);
+        if (detachedTargetId) {
+          this.sessions.delete(detachedTargetId);
+          this.attachedTargets.delete(sessionId);
+          this.ownerPageTargetByTarget.delete(detachedTargetId);
+          if (this.currentTargetId === detachedTargetId) {
+            this.currentTargetId = undefined;
+          }
+        }
+      }
+      return;
+    }
+
+    const ownerPageTargetId = this.getOwningPageTargetId(targetId);
+    const tab = this.tabManager.getTab(ownerPageTargetId);
     if (!tab) return;
 
     // Dialog handling
@@ -350,7 +389,7 @@ export class CdpConnection {
         timestamp: Math.round(Number(params.timestamp ?? Date.now()) * 1000),
         requestHeaders: normalizeHeaders(request.headers),
         requestBody: typeof request.postData === "string" ? request.postData : undefined,
-      });
+      }, targetId);
       return;
     }
 
@@ -363,7 +402,7 @@ export class CdpConnection {
         statusText: typeof response.statusText === "string" ? response.statusText : undefined,
         responseHeaders: normalizeHeaders(response.headers),
         mimeType: typeof response.mimeType === "string" ? response.mimeType : undefined,
-      });
+      }, targetId);
       return;
     }
 
@@ -373,6 +412,7 @@ export class CdpConnection {
       tab.updateNetworkFailure(
         requestId,
         typeof params.errorText === "string" ? params.errorText : "Unknown error",
+        targetId,
       );
       return;
     }
@@ -469,6 +509,7 @@ export class CdpConnection {
     );
     this.sessions.set(targetId, result.sessionId);
     this.attachedTargets.set(result.sessionId, targetId);
+    this.ownerPageTargetByTarget.set(targetId, targetId);
 
     // Register in tab state manager
     this.tabManager.addTab(targetId);
@@ -479,6 +520,11 @@ export class CdpConnection {
     await this.sessionCommand(targetId, "Network.enable").catch(() => {});
     await this.sessionCommand(targetId, "DOM.enable").catch(() => {});
     await this.sessionCommand(targetId, "Accessibility.enable").catch(() => {});
+    await this.sessionCommand(targetId, "Target.setAutoAttach", {
+      autoAttach: true,
+      waitForDebuggerOnStart: false,
+      flatten: true,
+    }).catch(() => {});
 
     return result.sessionId;
   }
@@ -551,6 +597,10 @@ export class CdpConnection {
   /** Check if a session exists for a given targetId. */
   hasSession(targetId: string): boolean {
     return this.sessions.has(targetId);
+  }
+
+  private getOwningPageTargetId(targetId: string): string {
+    return this.ownerPageTargetByTarget.get(targetId) ?? targetId;
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/daemon/src/command-dispatch.ts
+++ b/packages/daemon/src/command-dispatch.ts
@@ -950,8 +950,9 @@ export async function dispatchRequest(
               items.map(async (item) => {
                 if (item.failed || item.responseBody !== undefined || item.bodyError !== undefined) return;
                 try {
+                  const responseTargetId = tab.getNetworkOriginTargetId(item.seq) ?? target.id;
                   const body = await cdp.sessionCommand<{ body: string; base64Encoded: boolean }>(
-                    target.id,
+                    responseTargetId,
                     "Network.getResponseBody",
                     { requestId: item.requestId },
                   );

--- a/packages/daemon/src/tab-state.ts
+++ b/packages/daemon/src/tab-state.ts
@@ -43,8 +43,11 @@ export class TabState {
   consoleMessages = new RingBuffer<SeqConsoleMessage>(CONSOLE_CAPACITY);
   jsErrors = new RingBuffer<SeqJSError>(ERRORS_CAPACITY);
 
-  /** Lookup in-flight network requests by requestId for response/failure updates. */
-  private networkByRequestId = new Map<string, SeqNetworkRequest>();
+  /** Lookup in-flight network requests by originTargetId + requestId for response/failure updates. */
+  private networkByScopedId = new Map<string, SeqNetworkRequest>();
+
+  /** seq -> origin target ID, used to fetch bodies from iframe child targets. */
+  private networkOriginTargetBySeq = new Map<number, string>();
 
   /** seq of the last user-initiated action on this tab. */
   lastActionSeq = 0;
@@ -78,11 +81,20 @@ export class TabState {
 
   // --------------- Network events ---------------
 
-  addNetworkRequest(requestId: string, info: Omit<NetworkRequestInfo, "requestId">): void {
+  private buildScopedRequestId(originTargetId: string, requestId: string): string {
+    return `${originTargetId}:${requestId}`;
+  }
+
+  addNetworkRequest(
+    requestId: string,
+    info: Omit<NetworkRequestInfo, "requestId">,
+    originTargetId = this.targetId,
+  ): void {
     const seq = this.nextSeq();
     const entry: SeqNetworkRequest = { ...info, requestId, seq };
     this.networkRequests.push(entry);
-    this.networkByRequestId.set(requestId, entry);
+    this.networkByScopedId.set(this.buildScopedRequestId(originTargetId, requestId), entry);
+    this.networkOriginTargetBySeq.set(seq, originTargetId);
   }
 
   updateNetworkResponse(
@@ -93,8 +105,11 @@ export class TabState {
       responseHeaders?: Record<string, string>;
       mimeType?: string;
     },
+    originTargetId = this.targetId,
   ): void {
-    const existing = this.networkByRequestId.get(requestId);
+    const existing = this.networkByScopedId.get(
+      this.buildScopedRequestId(originTargetId, requestId),
+    );
     if (!existing) return;
     if (data.status !== undefined) existing.status = data.status;
     if (data.statusText !== undefined) existing.statusText = data.statusText;
@@ -102,11 +117,21 @@ export class TabState {
     if (data.mimeType !== undefined) existing.mimeType = data.mimeType;
   }
 
-  updateNetworkFailure(requestId: string, reason: string): void {
-    const existing = this.networkByRequestId.get(requestId);
+  updateNetworkFailure(
+    requestId: string,
+    reason: string,
+    originTargetId = this.targetId,
+  ): void {
+    const existing = this.networkByScopedId.get(
+      this.buildScopedRequestId(originTargetId, requestId),
+    );
     if (!existing) return;
     existing.failed = true;
     existing.failureReason = reason;
+  }
+
+  getNetworkOriginTargetId(seq: number): string | undefined {
+    return this.networkOriginTargetBySeq.get(seq);
   }
 
   // --------------- Console events ---------------
@@ -244,7 +269,8 @@ export class TabState {
 
   clearNetwork(): void {
     this.networkRequests.clear();
-    this.networkByRequestId.clear();
+    this.networkByScopedId.clear();
+    this.networkOriginTargetBySeq.clear();
   }
 
   clearConsole(): void {


### PR DESCRIPTION
### Description
This PR enables network request monitoring for cross-origin iframes by leveraging CDP's auto-attach mechanism.

Key changes:
- Enabled `Target.setAutoAttach` on page targets to automatically intercept child iframe targets.
- Implemented target ownership tracking (`ownerPageTargetByTarget`) to map iframe events back to their parent tab.
- Automatically enables the `Network` domain on new iframe targets and routes their events to the TabStateManager.

### Why?
Many modern sites (like video platforms) embed players or critical content inside cross-origin iframes. Previously, bb-browser could only see main-frame requests, missing important traffic like m3u8 playlist segments or XHR calls within those iframes.

### Test Result
Verified using a test case with a cross-origin iframe (`httpbin.org` embedded in `example.com`). All network requests (including the iframe's initial load and sub-requests) were successfully captured in the CLI output.
