### PR TITLE
feat: warn when local adapter overrides community version

### DIFF
--- a/packages/cli/src/commands/site.ts
+++ b/packages/cli/src/commands/site.ts
@@ -572,6 +572,15 @@ async function siteRun(
     }
   }
 
+  // Warn if local override is shadowing a community adapter
+  if (site.source === "local" && !options.json) {
+    const communityVersion = scanSites(COMMUNITY_SITES_DIR, "community").find(s => s.name === name);
+    if (communityVersion) {
+      console.error(`[local override] ${name} — ${site.filePath}`);
+      console.error(`  Community version also exists. Run \`bb-browser site update\` to check for updates.`);
+    }
+  }
+
   // 读取并解析 JS
   const jsContent = readFileSync(site.filePath, "utf-8");
 


### PR DESCRIPTION
When a local adapter in `~/.bb-browser/sites/` shadows a community version, print a warning to stderr during `site run`. Suppressed in `--json` mode.

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)