### PR TITLE
feat(cli): use system default browser with real user profile + nodeExec adapter mode

### DIFF
--- a/packages/cli/src/cdp-discovery.ts
+++ b/packages/cli/src/cdp-discovery.ts
@@ -1,9 +1,209 @@
 import { execFile, execSync, spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, lstatSync, readlinkSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { parseOpenClawJson } from "./openclaw-json.js";
+
+// Chromium-based browser identifiers for detection
+const CHROMIUM_BUNDLE_IDS = [
+  "com.google.Chrome",
+  "com.google.Chrome.beta",
+  "com.google.Chrome.dev",
+  "com.google.Chrome.canary",
+  "com.microsoft.edgemac",
+  "com.microsoft.edgemac.Beta",
+  "com.microsoft.edgemac.Dev",
+  "com.microsoft.edgemac.Canary",
+  "com.brave.Browser",
+  "com.brave.Browser.beta",
+  "com.brave.Browser.nightly",
+  "company.thebrowser.Browser", // Arc
+  "org.chromium.Chromium",
+  "com.operasoftware.Opera",
+  "com.vivaldi.Vivaldi",
+];
+
+const CHROMIUM_EXECUTABLE_PATTERNS = [
+  /chrome/i,
+  /chromium/i,
+  /microsoft.?edge/i,
+  /msedge/i,
+  /brave/i,
+  /arc/i,
+  /opera/i,
+  /vivaldi/i,
+];
+
+/**
+ * Determine if a browser executable path or bundle ID corresponds to a Chromium-based browser.
+ */
+function isChromiumBased(executableOrBundleId: string): boolean {
+  // Check against known bundle IDs first
+  if (CHROMIUM_BUNDLE_IDS.includes(executableOrBundleId)) {
+    return true;
+  }
+  // Check executable path/name patterns
+  return CHROMIUM_EXECUTABLE_PATTERNS.some((pattern) => pattern.test(executableOrBundleId));
+}
+
+/**
+ * Get the system default browser executable path.
+ * Returns null if the default browser cannot be determined.
+ */
+function getDefaultBrowserExecutable(): { executable: string; isChromium: boolean } | null {
+  if (process.platform === "darwin") {
+    return getDefaultBrowserDarwin();
+  }
+  if (process.platform === "linux") {
+    return getDefaultBrowserLinux();
+  }
+  if (process.platform === "win32") {
+    return getDefaultBrowserWin32();
+  }
+  return null;
+}
+
+function getDefaultBrowserDarwin(): { executable: string; isChromium: boolean } | null {
+  try {
+    // Read the default handler for https scheme from LaunchServices
+    const output = execSync(
+      "defaults read com.apple.LaunchServices/com.apple.launchservices.secure LSHandlers",
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 3000 },
+    );
+
+    // Find the bundle ID for the https handler
+    const lines = output.split("\n");
+    let bundleId: string | null = null;
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].includes("LSHandlerURLScheme") && lines[i].includes("https")) {
+        // Look backwards for LSHandlerRoleAll in the same block
+        for (let j = i - 1; j >= Math.max(0, i - 5); j--) {
+          const match = lines[j].match(/LSHandlerRoleAll\s*=\s*"([^"]+)"/);
+          if (match) {
+            bundleId = match[1];
+            break;
+          }
+        }
+        if (bundleId) break;
+      }
+    }
+
+    if (!bundleId) return null;
+
+    const chromium = isChromiumBased(bundleId);
+
+    // Find the app path via mdfind (Spotlight)
+    const appPath = execSync(
+      `mdfind "kMDItemCFBundleIdentifier == '${bundleId}'"`,
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 5000 },
+    ).trim().split("\n")[0];
+
+    if (!appPath) return null;
+
+    // Get the executable name from Info.plist
+    const execName = execSync(
+      `defaults read "${appPath}/Contents/Info" CFBundleExecutable`,
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 2000 },
+    ).trim();
+
+    if (!execName) return null;
+
+    const executable = `${appPath}/Contents/MacOS/${execName}`;
+    if (!existsSync(executable)) return null;
+
+    return { executable, isChromium: chromium };
+  } catch {
+    return null;
+  }
+}
+
+function getDefaultBrowserLinux(): { executable: string; isChromium: boolean } | null {
+  try {
+    // Get the default browser .desktop file name
+    const desktopFile = execSync(
+      "xdg-settings get default-web-browser",
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 3000 },
+    ).trim();
+
+    if (!desktopFile) return null;
+
+    // Search for the .desktop file in standard locations
+    const desktopDirs = [
+      "/usr/share/applications",
+      "/usr/local/share/applications",
+      path.join(os.homedir(), ".local/share/applications"),
+    ];
+
+    let execLine: string | null = null;
+    for (const dir of desktopDirs) {
+      const desktopPath = path.join(dir, desktopFile);
+      if (existsSync(desktopPath)) {
+        try {
+          const content = require("node:fs").readFileSync(desktopPath, "utf8") as string;
+          const match = content.match(/^Exec=(.+?)(?:\s+%[uUfF])?$/m);
+          if (match) {
+            execLine = match[1].trim();
+            break;
+          }
+        } catch {
+          // continue
+        }
+      }
+    }
+
+    if (!execLine) return null;
+
+    // Resolve to full path if needed
+    let executable = execLine.split(" ")[0];
+    if (!path.isAbsolute(executable)) {
+      try {
+        executable = execSync(`which ${executable}`, {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: 2000,
+        }).trim();
+      } catch {
+        return null;
+      }
+    }
+
+    if (!existsSync(executable)) return null;
+
+    return { executable, isChromium: isChromiumBased(executable) };
+  } catch {
+    return null;
+  }
+}
+
+function getDefaultBrowserWin32(): { executable: string; isChromium: boolean } | null {
+  try {
+    // Read the ProgId for https from the registry
+    const progId = execSync(
+      'reg query "HKCU\\Software\\Microsoft\\Windows\\Shell\\Associations\\UrlAssociations\\https\\UserChoice" /v ProgId',
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 3000 },
+    );
+    const progIdMatch = progId.match(/ProgId\s+REG_SZ\s+(\S+)/);
+    if (!progIdMatch) return null;
+
+    const id = progIdMatch[1];
+
+    // Get the open command for this ProgId
+    const openCmd = execSync(
+      `reg query "HKCR\\${id}\\shell\\open\\command" /ve`,
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 3000 },
+    );
+    const cmdMatch = openCmd.match(/REG_SZ\s+"?([^"%\s][^"]*?)(?:\.exe)"?/i);
+    if (!cmdMatch) return null;
+
+    const executable = `${cmdMatch[1]}.exe`.replace(/^"/, "");
+    if (!existsSync(executable)) return null;
+
+    return { executable, isChromium: isChromiumBased(executable) };
+  } catch {
+    return null;
+  }
+}
 
 const DEFAULT_CDP_PORT = 19825;
 const MANAGED_BROWSER_DIR = path.join(os.homedir(), ".bb-browser", "browser");
@@ -11,6 +211,149 @@ const MANAGED_USER_DATA_DIR = path.join(MANAGED_BROWSER_DIR, "user-data");
 const MANAGED_PORT_FILE = path.join(MANAGED_BROWSER_DIR, "cdp-port");
 const CDP_CACHE_FILE = path.join(os.tmpdir(), "bb-browser-cdp-cache.json");
 const CACHE_TTL_MS = 30000; // 缓存有效期 30 秒
+
+/**
+ * Get the real user-data-dir for a given browser executable.
+ * Returns null if it cannot be determined.
+ */
+function getRealUserDataDir(executable: string): string | null {
+  const home = os.homedir();
+
+  if (process.platform === "darwin") {
+    const appSupport = path.join(home, "Library", "Application Support");
+    if (/Google Chrome/i.test(executable)) return path.join(appSupport, "Google", "Chrome");
+    if (/Microsoft Edge/i.test(executable)) return path.join(appSupport, "Microsoft Edge");
+    if (/Brave/i.test(executable)) return path.join(appSupport, "BraveSoftware", "Brave-Browser");
+    if (/Arc/i.test(executable)) return path.join(appSupport, "Arc");
+    if (/Chromium/i.test(executable)) return path.join(appSupport, "Chromium");
+    if (/Opera/i.test(executable)) return path.join(appSupport, "com.operasoftware.Opera");
+    if (/Vivaldi/i.test(executable)) return path.join(appSupport, "Vivaldi");
+  }
+
+  if (process.platform === "linux") {
+    const configHome = process.env.XDG_CONFIG_HOME ?? path.join(home, ".config");
+    if (/google-chrome/i.test(executable)) return path.join(configHome, "google-chrome");
+    if (/chromium/i.test(executable)) return path.join(configHome, "chromium");
+    if (/microsoft-edge/i.test(executable) || /msedge/i.test(executable)) return path.join(configHome, "microsoft-edge");
+    if (/brave/i.test(executable)) return path.join(configHome, "BraveSoftware", "Brave-Browser");
+    if (/opera/i.test(executable)) return path.join(configHome, "opera");
+    if (/vivaldi/i.test(executable)) return path.join(configHome, "vivaldi");
+  }
+
+  if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA ?? "";
+    const appData = process.env.APPDATA ?? "";
+    if (/chrome/i.test(executable)) return path.join(localAppData, "Google", "Chrome", "User Data");
+    if (/msedge/i.test(executable) || /Microsoft Edge/i.test(executable)) return path.join(localAppData, "Microsoft", "Edge", "User Data");
+    if (/brave/i.test(executable)) return path.join(localAppData, "BraveSoftware", "Brave-Browser", "User Data");
+    if (/chromium/i.test(executable)) return path.join(localAppData, "Chromium", "User Data");
+    if (/opera/i.test(executable)) return path.join(appData, "Opera Software", "Opera Stable");
+    if (/vivaldi/i.test(executable)) return path.join(localAppData, "Vivaldi", "User Data");
+  }
+
+  return null;
+}
+
+/**
+ * Check if the real browser (not bb-browser managed instance) is currently running.
+ * Uses SingletonLock file presence as the primary signal on all platforms.
+ */
+function isRealBrowserRunning(realUserDataDir: string): boolean {
+  const singletonLock = path.join(realUserDataDir, "SingletonLock");
+
+  // Use lstatSync instead of existsSync because SingletonLock is a dangling symlink
+  // (points to "hostname-pid", not a real file path), so existsSync returns false
+  try {
+    lstatSync(singletonLock);
+  } catch {
+    return false;
+  }
+
+  // On macOS/Linux, SingletonLock is a symlink pointing to "hostname-pid"
+  // Verify the PID is still alive
+  if (process.platform !== "win32") {
+    try {
+      const target = readlinkSync(singletonLock);
+      const pidMatch = target.match(/-(\d+)$/);
+      if (pidMatch) {
+        const pid = Number(pidMatch[1]);
+        try {
+          process.kill(pid, 0); // signal 0 = check if process exists
+          return true;
+        } catch {
+          return false; // process not found, stale lock
+        }
+      }
+    } catch {
+      // Can't read symlink, assume running
+      return true;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Gracefully quit the real browser process so we can restart it with CDP enabled.
+ * Kills all processes sharing the same executable path to avoid SingletonLock conflicts.
+ * Returns true if the browser was successfully stopped.
+ */
+async function quitRealBrowser(realUserDataDir: string, executable: string): Promise<boolean> {
+  if (process.platform === "win32") {
+    try {
+      const exeName = path.basename(executable);
+      execSync(`taskkill /F /IM "${exeName}"`, { stdio: "ignore" });
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // macOS / Linux: kill all processes whose executable path starts with the app bundle
+  // (covers main process + all Helper/Renderer/GPU child processes)
+  const appDir = process.platform === "darwin"
+    ? executable.replace(/\/Contents\/MacOS\/[^/]+$/, "") // e.g. /Applications/Microsoft Edge.app
+    : path.dirname(executable);
+
+  try {
+    // Get all PIDs whose command starts with the app directory
+    const psOutput = execSync(
+      `pgrep -f "${appDir.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"`,
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: 3000 },
+    ).trim();
+
+    const pids = psOutput.split("\n").map(Number).filter((n) => n > 0 && n !== process.pid);
+    if (pids.length === 0) return true;
+
+    // Send SIGTERM to all
+    for (const pid of pids) {
+      try { process.kill(pid, "SIGTERM"); } catch {}
+    }
+
+    // Wait up to 5s for all to exit
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      const stillAlive = pids.filter((pid) => {
+        try { process.kill(pid, 0); return true; } catch { return false; }
+      });
+      if (stillAlive.length === 0) break;
+      // Force kill stragglers near deadline
+      if (Date.now() + 600 >= deadline) {
+        for (const pid of stillAlive) {
+          try { process.kill(pid, "SIGKILL"); } catch {}
+        }
+      }
+    }
+
+    // Extra wait for OS to release the SingletonLock file
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function execFileAsync(command: string, args: string[], timeout: number): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -85,6 +428,19 @@ async function canConnect(host: string, port: number): Promise<boolean> {
 }
 
 export function findBrowserExecutable(): string | null {
+  // Try the system default browser first
+  const defaultBrowser = getDefaultBrowserExecutable();
+  if (defaultBrowser) {
+    if (defaultBrowser.isChromium) {
+      return defaultBrowser.executable;
+    }
+    // Default browser is not Chromium-based; warn and fall through to known candidates
+    console.error(
+      `[bb-browser] 系统默认浏览器不是 Chromium 内核，无法直接控制。正在查找 Chrome/Edge/Brave...`,
+    );
+  }
+
+  // Fall back to known Chromium-based browser candidates
   if (process.platform === "darwin") {
     const candidates = [
       "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
@@ -151,33 +507,59 @@ export async function launchManagedBrowser(port: number = DEFAULT_CDP_PORT): Pro
     return null;
   }
 
-  await mkdir(MANAGED_USER_DATA_DIR, { recursive: true });
+  // Prefer the real user profile so the browser has full history/bookmarks/passwords
+  const realUserDataDir = getRealUserDataDir(executable);
+  let userDataDir: string;
 
-  // Set profile name so the Chrome window shows "bb-browser" in the title bar
-  const defaultProfileDir = path.join(MANAGED_USER_DATA_DIR, "Default");
-  const prefsPath = path.join(defaultProfileDir, "Preferences");
-  await mkdir(defaultProfileDir, { recursive: true });
-  try {
-    let prefs: Record<string, unknown> = {};
-    try { prefs = JSON.parse(await readFile(prefsPath, "utf8")); } catch {}
-    if (!(prefs.profile as Record<string, unknown>)?.name || (prefs.profile as Record<string, unknown>).name !== "bb-browser") {
-      prefs.profile = { ...(prefs.profile as Record<string, unknown> || {}), name: "bb-browser" };
-      await writeFile(prefsPath, JSON.stringify(prefs), "utf8");
+  if (realUserDataDir && existsSync(realUserDataDir)) {
+    if (isRealBrowserRunning(realUserDataDir)) {
+      // Real browser is running without CDP — restart it with CDP enabled
+      console.error("[bb-browser] 检测到浏览器正在运行，正在重启以启用调试模式（历史记录/书签/密码将保留）...");
+      const stopped = await quitRealBrowser(realUserDataDir, executable);
+      if (!stopped) {
+        // Could not stop the real browser; fall back to isolated profile
+        console.error("[bb-browser] 无法关闭已运行的浏览器，将使用独立 profile 启动（不含历史记录/书签）");
+        userDataDir = MANAGED_USER_DATA_DIR;
+      } else {
+        userDataDir = realUserDataDir;
+      }
+    } else {
+      userDataDir = realUserDataDir;
     }
-  } catch {}
+  } else {
+    userDataDir = MANAGED_USER_DATA_DIR;
+  }
 
+  if (userDataDir === MANAGED_USER_DATA_DIR) {
+    // Only set up the managed profile name when using the isolated dir
+    await mkdir(MANAGED_USER_DATA_DIR, { recursive: true });
+    const defaultProfileDir = path.join(MANAGED_USER_DATA_DIR, "Default");
+    const prefsPath = path.join(defaultProfileDir, "Preferences");
+    await mkdir(defaultProfileDir, { recursive: true });
+    try {
+      let prefs: Record<string, unknown> = {};
+      try { prefs = JSON.parse(await readFile(prefsPath, "utf8")); } catch {}
+      if (!(prefs.profile as Record<string, unknown>)?.name || (prefs.profile as Record<string, unknown>).name !== "bb-browser") {
+        prefs.profile = { ...(prefs.profile as Record<string, unknown> || {}), name: "bb-browser" };
+        await writeFile(prefsPath, JSON.stringify(prefs), "utf8");
+      }
+    } catch {}
+  }
+
+  const usingRealProfile = userDataDir !== MANAGED_USER_DATA_DIR;
   const args = [
     `--remote-debugging-port=${port}`,
-    `--user-data-dir=${MANAGED_USER_DATA_DIR}`,
+    `--user-data-dir=${userDataDir}`,
     "--no-first-run",
     "--no-default-browser-check",
-    "--disable-sync",
-    "--disable-background-networking",
-    "--disable-component-update",
-    "--disable-features=Translate,MediaRouter",
-    "--disable-session-crashed-bubble",
-    "--hide-crash-restore-bubble",
-    "about:blank",
+    // When using the real profile, don't pass a URL so the browser restores
+    // the previous session (tabs) according to the user's startup settings.
+    // For the isolated managed profile, open about:blank to avoid a blank window.
+    ...(!usingRealProfile ? [
+      "--disable-session-crashed-bubble",
+      "--hide-crash-restore-bubble",
+      "about:blank",
+    ] : []),
   ];
 
   try {
@@ -193,7 +575,8 @@ export async function launchManagedBrowser(port: number = DEFAULT_CDP_PORT): Pro
   await mkdir(MANAGED_BROWSER_DIR, { recursive: true });
   await writeFile(MANAGED_PORT_FILE, String(port), "utf8");
 
-  const deadline = Date.now() + 8000;
+  // Real profiles take longer to start; allow up to 15s
+  const deadline = Date.now() + 15000;
   while (Date.now() < deadline) {
     if (await canConnect("127.0.0.1", port)) {
       return { host: "127.0.0.1", port };

--- a/packages/cli/src/cdp-discovery.ts
+++ b/packages/cli/src/cdp-discovery.ts
@@ -1,9 +1,79 @@
 import { execFile, execSync, spawn } from "node:child_process";
-import { existsSync, lstatSync, readlinkSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readlinkSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { parseOpenClawJson } from "./openclaw-json.js";
+
+/**
+ * Read the CDP port from a DevToolsActivePort file.
+ * The file contains two lines: port number on line 1, optional ws path on line 2.
+ * Returns null if the file does not exist or is malformed.
+ */
+function readDevToolsActivePortFile(userDataDir: string): number | null {
+  const filePath = path.join(userDataDir, "DevToolsActivePort");
+  try {
+    const content = readFileSync(filePath, "utf8");
+    const port = Number.parseInt(content.split("\n")[0].trim(), 10);
+    if (Number.isInteger(port) && port > 0) return port;
+  } catch {}
+  return null;
+}
+
+/**
+ * Scan all known browser user-data directories for a DevToolsActivePort file.
+ * Returns the first reachable CDP endpoint found, or null.
+ */
+async function discoverViaDevToolsActivePort(): Promise<{ host: string; port: number } | null> {
+  const home = os.homedir();
+  const candidates: string[] = [];
+
+  if (process.platform === "darwin") {
+    const appSupport = path.join(home, "Library", "Application Support");
+    candidates.push(
+      path.join(appSupport, "Microsoft Edge"),
+      path.join(appSupport, "Google", "Chrome"),
+      path.join(appSupport, "BraveSoftware", "Brave-Browser"),
+      path.join(appSupport, "Chromium"),
+      path.join(appSupport, "Arc"),
+      path.join(appSupport, "com.operasoftware.Opera"),
+      path.join(appSupport, "Vivaldi"),
+    );
+  } else if (process.platform === "linux") {
+    const configHome = process.env.XDG_CONFIG_HOME ?? path.join(home, ".config");
+    candidates.push(
+      path.join(configHome, "microsoft-edge"),
+      path.join(configHome, "google-chrome"),
+      path.join(configHome, "chromium"),
+      path.join(configHome, "BraveSoftware", "Brave-Browser"),
+      path.join(configHome, "opera"),
+      path.join(configHome, "vivaldi"),
+    );
+  } else if (process.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA ?? "";
+    const appData = process.env.APPDATA ?? "";
+    if (localAppData) {
+      candidates.push(
+        path.join(localAppData, "Microsoft", "Edge", "User Data"),
+        path.join(localAppData, "Google", "Chrome", "User Data"),
+        path.join(localAppData, "BraveSoftware", "Brave-Browser", "User Data"),
+        path.join(localAppData, "Chromium", "User Data"),
+        path.join(localAppData, "Vivaldi", "User Data"),
+      );
+    }
+    if (appData) {
+      candidates.push(path.join(appData, "Opera Software", "Opera Stable"));
+    }
+  }
+
+  for (const dir of candidates) {
+    const port = readDevToolsActivePortFile(dir);
+    if (port !== null && await canConnect("127.0.0.1", port)) {
+      return { host: "127.0.0.1", port };
+    }
+  }
+  return null;
+}
 
 // Chromium-based browser identifiers for detection
 const CHROMIUM_BUNDLE_IDS = [
@@ -140,7 +210,7 @@ function getDefaultBrowserLinux(): { executable: string; isChromium: boolean } |
       const desktopPath = path.join(dir, desktopFile);
       if (existsSync(desktopPath)) {
         try {
-          const content = require("node:fs").readFileSync(desktopPath, "utf8") as string;
+          const content = readFileSync(desktopPath, "utf8");
           const match = content.match(/^Exec=(.+?)(?:\s+%[uUfF])?$/m);
           if (match) {
             execLine = match[1].trim();
@@ -513,6 +583,15 @@ export async function launchManagedBrowser(port: number = DEFAULT_CDP_PORT): Pro
 
   if (realUserDataDir && existsSync(realUserDataDir)) {
     if (isRealBrowserRunning(realUserDataDir)) {
+      // Check if the running browser already has CDP enabled (DevToolsActivePort exists)
+      const existingPort = readDevToolsActivePortFile(realUserDataDir);
+      if (existingPort !== null && await canConnect("127.0.0.1", existingPort)) {
+        // Browser is already running with CDP — reuse it directly, no restart needed
+        await mkdir(MANAGED_BROWSER_DIR, { recursive: true });
+        await writeFile(MANAGED_PORT_FILE, String(existingPort), "utf8");
+        return { host: "127.0.0.1", port: existingPort };
+      }
+
       // Real browser is running without CDP — restart it with CDP enabled
       console.error("[bb-browser] 检测到浏览器正在运行，正在重启以启用调试模式（历史记录/书签/密码将保留）...");
       const stopped = await quitRealBrowser(realUserDataDir, executable);
@@ -632,13 +711,22 @@ export async function discoverCdpPort(): Promise<{ host: string; port: number } 
     }
   }
 
-  // 优先级5: 自动启动浏览器
+  // 优先级5: DevToolsActivePort 文件自动发现
+  // 当用户在 chrome://inspect 或 edge://inspect 中开启了远程调试后，
+  // 浏览器会将动态分配的 CDP 端口写入 DevToolsActivePort 文件。
+  // 这样无需重启浏览器即可直接连接。
+  const viaActivePort = await discoverViaDevToolsActivePort();
+  if (viaActivePort) {
+    return viaActivePort;
+  }
+
+  // 优先级6: 自动启动浏览器
   const launched = await launchManagedBrowser();
   if (launched) {
     return launched;
   }
 
-  // 优先级6: 自动检测 OpenClaw（不带 --openclaw 参数时）
+  // 优先级7: 自动检测 OpenClaw（不带 --openclaw 参数时）
   if (!process.argv.includes("--openclaw")) {
     const detectedOpenClaw = await tryOpenClaw();
     if (detectedOpenClaw && await canConnect(detectedOpenClaw.host, detectedOpenClaw.port)) {

--- a/packages/cli/src/commands/site.ts
+++ b/packages/cli/src/commands/site.ts
@@ -59,6 +59,8 @@ interface SiteMeta {
   args: Record<string, ArgDef>;
   capabilities?: string[];
   readOnly?: boolean;
+  /** When true, the adapter runs in Node.js (no browser required, no CORS). */
+  nodeExec?: boolean;
   example?: string;
   filePath: string;
   source: "local" | "community";
@@ -113,6 +115,7 @@ function parseSiteMeta(filePath: string, source: "local" | "community"): SiteMet
         args: metaJson.args || {},
         capabilities: metaJson.capabilities,
         readOnly: metaJson.readOnly,
+        nodeExec: metaJson.nodeExec,
         example: metaJson.example,
         filePath,
         source,
@@ -648,6 +651,51 @@ async function siteRun(
       console.log(JSON.stringify({ id: "openclaw", success: true, data: parsed }));
     } else {
       console.log(JSON.stringify(parsed, null, 2));
+    }
+    return;
+  }
+
+  // Node.js execution path: no browser, no CORS, no timeout issues
+  if (site.nodeExec) {
+    let result: unknown;
+    try {
+      // Wrap the adapter function body and invoke it with args
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      const fn = new Function(`return (${jsBody})`)() as (args: Record<string, unknown>) => Promise<unknown>;
+      result = await fn(argMap);
+    } catch (e) {
+      const errMsg = e instanceof Error ? e.message : String(e);
+      if (options.json) {
+        console.log(JSON.stringify({ success: false, error: errMsg }));
+      } else {
+        console.error(`[error] site ${name}: ${errMsg}`);
+      }
+      process.exit(1);
+    }
+
+    if (typeof result === "object" && result !== null && "error" in result) {
+      const errObj = result as { error: string; hint?: string; action?: string };
+      if (options.json) {
+        console.log(JSON.stringify({ success: false, ...errObj }));
+      } else {
+        console.error(`[error] site ${name}: ${errObj.error}`);
+        if (errObj.hint) console.error(`  提示: ${errObj.hint}`);
+        if (errObj.action) console.error(`  操作: ${errObj.action}`);
+      }
+      process.exit(1);
+    }
+
+    if (options.jq) {
+      const { applyJq } = await import("../jq.js");
+      const expr = options.jq.replace(/^\.data\./, ".");
+      const results = applyJq(result, expr);
+      for (const r of results) {
+        console.log(typeof r === "string" ? r : JSON.stringify(r));
+      }
+    } else if (options.json) {
+      console.log(JSON.stringify({ success: true, data: result }));
+    } else {
+      console.log(JSON.stringify(result, null, 2));
     }
     return;
   }

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -10,7 +10,8 @@ export default defineConfig({
   banner: {
     js: "#!/usr/bin/env node",
   },
-  // ws 使用 Node.js 内置模块，需要标记为外部依赖
-  external: ["ws"],
+  // Node.js built-in modules must be external so they are imported as ESM,
+  // not bundled via __require() which fails in ESM context.
+  external: ["ws", "node:fs", "fs", "node:path", "path", "node:os", "os", "node:child_process", "child_process"],
   noExternal: [],
 });


### PR DESCRIPTION
## Summary

This PR adds three improvements to browser control in bb-browser:

### 1. Use system default browser (with Chromium fallback)

Instead of hardcoding Chrome as the only option, bb-browser now:
- Detects the system default browser (macOS/Linux/Windows)
- Uses it if it's Chromium-based (Chrome, Edge, Brave, Arc, Vivaldi, Opera, Chromium)
- Warns and falls back to searching for known Chromium browsers if the default is not Chromium-based

### 2. Use real user profile (with history, bookmarks, passwords)

Previously bb-browser launched a blank isolated profile. Now it:
- Detects the real user-data-dir for the discovered browser
- If the browser is running without CDP, gracefully restarts it with `--remote-debugging-port` while keeping the real profile
- Preserves session tabs on restart (no `about:blank` override)
- Uses `lstatSync` instead of `existsSync` to correctly detect `SingletonLock` (which is a dangling symlink on macOS/Linux)

### 3. Attach to already-running browser via DevToolsActivePort (no restart needed)

When the user enables remote debugging in `chrome://inspect/#remote-debugging` or `edge://inspect/#remote-debugging`, the browser writes a `DevToolsActivePort` file containing the dynamic CDP port. bb-browser now:
- Scans all known browser user-data directories for `DevToolsActivePort` files (Edge, Chrome, Brave, Chromium, Arc, Opera, Vivaldi on macOS/Linux/Windows)
- Connects directly to the running browser **without restarting it**
- Falls back to the restart approach only when no `DevToolsActivePort` is found

This means users who enable remote debugging once never need to have their browser restarted again.

**One-time setup:** Open `edge://inspect/#remote-debugging` (or `chrome://inspect`), enable remote debugging, restart the browser once. After that, bb-browser connects instantly without ever restarting the browser.

### 4. `nodeExec` adapter mode to bypass browser CORS

Site adapters that only need HTTP APIs (no DOM interaction) can now set `"nodeExec": true` in their `@meta` block. bb-browser will execute them directly in the Node.js process instead of via `Runtime.evaluate`, bypassing browser CORS restrictions entirely.

### Bug fix: `tsup.config.ts` Node.js built-ins as ESM externals

Node.js built-in modules (`fs`, `path`, `os`, `child_process`) are now marked as `external` in tsup config. This ensures they are emitted as ESM static imports (`import { readFileSync } from "fs"`) rather than bundled via `__require()`, which throws `'Dynamic require of "fs" is not supported'` at runtime in ESM context.

## Test plan

- [ ] Default browser detection works on macOS (tested with Edge as default)
- [ ] Real user profile loads with history/bookmarks/passwords
- [ ] Session tabs are restored after restart
- [ ] `DevToolsActivePort` discovery connects without restarting browser (tested: Edge PID unchanged)
- [ ] Falls back to restart when no `DevToolsActivePort` present
- [ ] `nodeExec` adapters run in Node.js context with no CORS errors
- [ ] All existing tests pass (`pnpm test`: 119 daemon + 24 cli tests, 0 failures)