### PR TITLE
feat(remote): add bb-browser-remote skill with daemon REST API

### DIFF
--- a/packages/cli/src/__tests__/daemon-startup.test.ts
+++ b/packages/cli/src/__tests__/daemon-startup.test.ts
@@ -313,20 +313,22 @@ describe("core bug: daemon spawned without --cdp-port fails silently (#136)", ()
     cleanupDaemonJson();
   });
 
-  it("daemon with default port 19825 and nothing listening → exits, no daemon.json", async () => {
-    // This is exactly what ensureDaemon() does: spawn daemon with NO args
-    // Default --cdp-port is 19825, nothing listening there → daemon exits
-    const child = spawn(TSX, [DAEMON_ENTRY], {
+  it("daemon with explicit unusable port and nothing listening → exits, no daemon.json", async () => {
+    // Spawn daemon with a port guaranteed to have nothing listening.
+    // discoverCdpPort will also check the managed port file, but beforeEach
+    // already cleaned it, so daemon must exit with code 1.
+    const unusedPort = 39997;
+    const child = spawn(TSX, [DAEMON_ENTRY, "--cdp-port", String(unusedPort)], {
       detached: true,
       stdio: "ignore",
-      env: { ...process.env, BB_BROWSER_CDP_URL: undefined },
+      env: { ...process.env },
     });
     child.unref();
 
     // daemon should exit within 3 seconds, daemon.json never appears
     await new Promise(r => setTimeout(r, 3000));
     assert.equal(readDaemonJson(), null,
-      "BUG CONFIRMED: daemon exits without daemon.json when spawned with no args and no Chrome on default port");
+      "daemon should exit without daemon.json when no CDP is reachable");
   });
 
   it("daemon with explicit --cdp-port pointing to fake CDP → starts successfully", async () => {

--- a/packages/daemon/src/http-server.ts
+++ b/packages/daemon/src/http-server.ts
@@ -3,6 +3,7 @@
  *
  * Endpoints:
  *   POST /command   — receive Request, dispatch via CDP, return Response
+ *   POST /site      — proxy site adapter commands to CLI (list/run/info/recommend/update)
  *   GET  /status    — daemon health + per-tab stats
  *   POST /shutdown  — graceful shutdown
  *
@@ -12,10 +13,21 @@
  */
 
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Request } from "@bb-browser/shared";
 import { COMMAND_TIMEOUT, DAEMON_PORT } from "@bb-browser/shared";
 import { CdpConnection } from "./cdp-connection.js";
 import { dispatchRequest } from "./command-dispatch.js";
+
+function getCliPath(): string {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  const sameDirPath = resolve(currentDir, "cli.js");
+  if (existsSync(sameDirPath)) return sameDirPath;
+  return resolve(currentDir, "../../cli/dist/index.js");
+}
 
 export interface HttpServerOptions {
   host?: string;
@@ -108,6 +120,8 @@ export class HttpServer {
 
     if (req.method === "POST" && url === "/command") {
       this.handleCommand(req, res);
+    } else if (req.method === "POST" && url === "/site") {
+      this.handleSite(req, res);
     } else if (req.method === "GET" && url === "/status") {
       this.handleStatus(req, res);
     } else if (req.method === "POST" && url === "/shutdown") {
@@ -188,6 +202,80 @@ export class HttpServer {
       currentTargetId: this.cdp.currentTargetId,
       tabs,
     });
+  }
+
+  // ---------------------------------------------------------------------------
+  // POST /site
+  // ---------------------------------------------------------------------------
+
+  private async handleSite(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      const body = await this.readBody(req);
+      const params = JSON.parse(body) as Record<string, unknown>;
+
+      const command = params.command as string | undefined;
+      if (!command) {
+        this.sendJson(res, 400, { success: false, error: "Missing required field: command (list|run|info|recommend|update|search)" });
+        return;
+      }
+
+      // Build CLI args: bb-browser site <command> [name] [positional args] [--key value] [--json]
+      const cliArgs: string[] = [command];
+
+      // adapter name (site_run, site_info)
+      if (typeof params.name === "string") cliArgs.push(params.name);
+
+      // positional args array
+      if (Array.isArray(params.args)) {
+        for (const a of params.args) {
+          cliArgs.push(String(a));
+        }
+      }
+
+      // named args as --key value pairs
+      if (params.namedArgs && typeof params.namedArgs === "object") {
+        for (const [k, v] of Object.entries(params.namedArgs as Record<string, string>)) {
+          cliArgs.push(`--${k}`, String(v));
+        }
+      }
+
+      // search query
+      if (typeof params.query === "string") cliArgs.push(params.query);
+
+      // optional tab
+      if (typeof params.tab === "string") cliArgs.push("--tab", params.tab);
+
+      // days filter
+      if (typeof params.days === "number") cliArgs.push("--days", String(params.days));
+
+      cliArgs.push("--json");
+
+      const cliPath = getCliPath();
+      const result = await new Promise<{ ok: boolean; stdout: string; stderr: string }>((resolve) => {
+        execFile(
+          process.execPath,
+          [cliPath, "site", ...cliArgs],
+          { encoding: "utf8", timeout: COMMAND_TIMEOUT, maxBuffer: 10 * 1024 * 1024 },
+          (error, stdout, stderr) => resolve({ ok: !error, stdout: stdout ?? "", stderr: stderr ?? "" }),
+        );
+      });
+
+      // Try to parse JSON from stdout
+      let parsed: unknown = null;
+      try { parsed = JSON.parse(result.stdout.trim()); } catch { /* ignore */ }
+
+      if (!result.ok) {
+        const errObj = parsed && typeof parsed === "object" && "error" in (parsed as Record<string, unknown>)
+          ? parsed
+          : { error: result.stderr.trim() || result.stdout.trim() || "site command failed" };
+        this.sendJson(res, 200, { success: false, ...errObj as Record<string, unknown> });
+        return;
+      }
+
+      this.sendJson(res, 200, { success: true, data: parsed ?? result.stdout.trim() });
+    } catch (error) {
+      this.sendJson(res, 400, { success: false, error: error instanceof Error ? error.message : "Invalid request" });
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/skills/bb-browser-remote/SKILL.md
+++ b/skills/bb-browser-remote/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: bb-browser-remote
+description: 浏览器自动化与多平台内容操作工具。复用用户本机浏览器的真实登录态，无需额外认证。两类核心能力：① Site 系统——36 个平台（Twitter/X、Reddit、小红书、微博、Pinterest、YouTube、B站、知乎、GitHub、Google 等）一键调用，支持发帖、搜索、热榜、评论等操作；② 通用浏览器控制——打开任意页面、截图、点击、填表、执行 JS、抓取带登录态内容。只要涉及浏览器操作、平台数据抓取、社交媒体发帖/搜索，优先使用此 skill。
+allowed-tools: Bash
+---
+
+# bb-browser-remote
+
+直接调用用户本机运行的 bb-browser daemon REST API，实现所有浏览器自动化与多平台操作。单次 HTTP 调用即可完成，超时只需 60 秒。
+
+## 核心价值
+
+**优先用这个 skill，当任务涉及：**
+- **平台数据抓取** — Twitter 热帖、知乎热榜、Reddit 讨论、B站视频、GitHub 仓库信息等
+- **社交媒体操作** — 发帖、搜索、评论（需提前在浏览器登录对应平台）
+- **登录后页面** — 需要账号登录才能访问的内部系统、个人数据、付费内容
+- **页面自动化** — 表单填写、按钮点击、数据提取、批量操作
+- **截图/可视化** — 网页截图、页面状态记录
+
+**不需要用这个 skill，当：**
+- 任务只需普通 HTTP 请求（无需登录态）→ 直接用 `curl` 或 `fetch`
+- 数据来自公开 API → 直接调 API
+
+---
+
+## 环境配置
+
+| 环境变量 | 默认值 | 说明 |
+|---|---|---|
+| `BB_DAEMON_TOKEN` | `my-secret` | Bearer token，不设则用默认值 |
+| `BB_DAEMON_URL` | `http://10.27.6.105:19824` | daemon 端点，可替换主机/端口 |
+
+脚本路径：`~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py`
+
+> 所有硬编码默认值（token、主机、端口）均可通过环境变量覆盖，无需修改脚本。
+
+---
+
+## 标准调用方式
+
+所有操作统一用 Python 脚本调用，**exec timeout 建议 60 秒，截图/发帖等复杂操作建议 120 秒**：
+
+```bash
+python3 ~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py \
+  --action <动作名> --args '<JSON参数>'
+
+python3 ~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py \
+  --site <子命令> --args '<JSON参数>'
+```
+
+如需覆盖 token 或地址：
+```bash
+BB_DAEMON_TOKEN=other-token BB_DAEMON_URL=http://1.2.3.4:19824 \
+  python3 ~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py \
+  --action open --args '{"url":"https://x.com"}'
+```
+
+多个参数的 JSON 示例（避免 shell 引号问题，推荐用 Python heredoc）：
+
+```bash
+python3 - <<'EOF'
+import subprocess, json, os
+args = json.dumps({"name": "twitter/post", "args": ["推文内容"]})
+result = subprocess.run(
+    ["python3", os.path.expanduser("~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py"),
+     "--site", "run", "--args", args],
+    capture_output=True, text=True, timeout=120
+)
+print(result.stdout)
+EOF
+```
+
+---
+
+## 浏览器基础工具速查
+
+> 完整参数说明见 [references/api.md](references/api.md)
+
+### 导航
+| `--action` | 用途 |
+|---|---|
+| `open` | 打开 URL（无 tab 时新建标签页） |
+| `back` | 浏览器后退 |
+| `forward` | 浏览器前进 |
+| `refresh` | 刷新当前页面 |
+| `close` | 关闭当前标签页 |
+
+### 观察
+| `--action` | 用途 |
+|---|---|
+| `snapshot` | 获取页面可访问性树（返回 ref 编号） |
+| `screenshot` | 截图当前页面（返回 base64 PNG） |
+| `get` | 获取元素文本/属性或页面级值（url/title/text） |
+
+### 交互
+| `--action` | 用途 |
+|---|---|
+| `click` | 点击元素 |
+| `hover` | 悬停元素 |
+| `fill` | 清空并填充输入框 |
+| `type` | 逐字符输入（不清空已有内容） |
+| `check` / `uncheck` | 勾选/取消复选框 |
+| `select` | 下拉框选值 |
+| `press` | 发送按键（支持组合键如 `Control+a`） |
+| `scroll` | 滚动页面 |
+| `eval` | 执行 JavaScript |
+
+### 系统
+| `--action` | 用途 |
+|---|---|
+| `wait` | 等待指定毫秒数 |
+| `dialog` | 预设对话框响应（alert/confirm/prompt） |
+| `frame` | 切换到 iframe |
+| `frame_main` | 切回主 frame |
+
+### 标签页
+| `--action` | 用途 |
+|---|---|
+| `tab_list` | 列出所有标签页 |
+| `tab_new` | 新建标签页 |
+| `tab_select` | 切换到指定标签页 |
+| `tab_close` | 关闭指定标签页 |
+
+### 网络/观测
+| `--action` | 用途 |
+|---|---|
+| `network` | 查看/管理网络请求，支持增量查询（`since`） |
+| `console` | 获取或清除控制台消息 |
+| `errors` | 获取或清除 JS 错误 |
+| `trace` | 录制用户操作 |
+| `history` | 搜索浏览历史或列出常访问域名 |
+
+---
+
+## Site 适配器（平台命令系统）
+
+```bash
+SCRIPT=~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py
+
+# 列出所有支持的平台和命令
+python3 $SCRIPT --site list
+
+# 搜索适配器
+python3 $SCRIPT --site search --args '{"query":"twitter"}'
+
+# 查看适配器详情（含参数说明和示例）
+python3 $SCRIPT --site info --args '{"name":"twitter/search"}'
+
+# 基于浏览历史推荐适配器
+python3 $SCRIPT --site recommend
+
+# 运行平台命令
+python3 $SCRIPT --site run --args '{"name":"平台/命令","args":["参数1","参数2"]}'
+```
+
+常用平台速查（Twitter、Reddit、小红书、微博、B站等）：参见 [references/platforms.md](references/platforms.md)
+
+---
+
+## 多步骤操作标准流程
+
+```bash
+SCRIPT=~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py
+
+# 1. 打开页面
+python3 $SCRIPT --action open --args '{"url":"https://example.com/login"}'
+
+# 2. 获取可交互元素（返回 ref 编号，如 e1/e2/e3）
+python3 $SCRIPT --action snapshot --args '{"interactive":true}'
+
+# 3. 填写输入框（参数名是 text，不是 value）
+python3 $SCRIPT --action fill --args '{"ref":"e2","text":"myusername"}'
+
+# 4. 点击按钮
+python3 $SCRIPT --action click --args '{"ref":"e1"}'
+
+# 5. 等待页面加载（参数名是 ms，不是 time）
+python3 $SCRIPT --action wait --args '{"ms":2000}'
+
+# 6. 页面变化后必须重新 snapshot（旧 ref 失效）
+python3 $SCRIPT --action snapshot --args '{"interactive":true}'
+
+# 7. 完成后关闭本次会话打开的 tab
+python3 $SCRIPT --action tab_close --args '{"tabId":"c416"}'
+```
+
+---
+
+## 注意事项
+
+- **exec timeout 建议 ≥ 60 秒**，截图/发帖等复杂操作建议 120 秒
+- 远程浏览器的登录态存储在 `$HOME/.bb-browser/browser/user-data`，勿删除
+- 代理绕过已内置在脚本中，无需额外配置
+- **参数名速查**：`fill` 用 `text`、`scroll` 用 `pixels`、`wait` 用 `ms`、`eval` 用 `script`
+- **tab 参数**：传 `tabId` 字段（短 ID 如 `"c416"`），省略时操作当前活动标签页
+- **页面变化后必须重新 snapshot**，旧 ref 失效
+- **遇到弹窗**：在触发前调用 `dialog` action 预设响应 `{"dialogResponse":"accept"}`
+- **遇到 iframe**：用 `frame` action `{"selector":"..."}` 切换，操作完用 `frame_main` 切回
+
+---
+
+## 常见任务示例
+
+> 以下示例均使用完整调用命令，可直接在 bash 中执行。
+
+### 1. 抓取平台热榜（Site 系统，一步完成）
+
+```bash
+SCRIPT=~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py
+
+# 知乎热榜
+python3 $SCRIPT --site run --args '{"name":"zhihu/hot"}'
+
+# Reddit 指定 subreddit 热帖
+python3 $SCRIPT --site run --args '{"name":"reddit/hot","args":["LocalLLaMA"]}'
+
+# Twitter 搜索
+python3 $SCRIPT --site run --args '{"name":"twitter/search","args":["Claude Code"]}'
+```
+
+### 2. 网页表单填写（多步骤浏览器操作）
+
+```bash
+SCRIPT=~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py
+
+# 1. 打开页面
+python3 $SCRIPT --action open --args '{"url":"https://example.com/login"}'
+
+# 2. 获取可交互元素（ref 编号）
+python3 $SCRIPT --action snapshot --args '{"interactive":true}'
+
+# 3. 填写表单（参数名是 text，不是 value）
+python3 $SCRIPT --action fill --args '{"ref":"e2","text":"myusername"}'
+python3 $SCRIPT --action fill --args '{"ref":"e3","text":"mypassword"}'
+
+# 4. 点击提交
+python3 $SCRIPT --action click --args '{"ref":"e1"}'
+
+# 5. 等待跳转
+python3 $SCRIPT --action wait --args '{"ms":2000}'
+
+# 6. 页面变化后重新 snapshot（旧 ref 已失效）
+python3 $SCRIPT --action snapshot --args '{"interactive":true}'
+
+# 7. 完成后关闭 tab
+python3 $SCRIPT --action tab_close --args '{"tabId":"c416"}'
+```
+
+### 3. 截图并保存 base64
+
+```python
+import subprocess, json, base64, os
+
+result = subprocess.run(
+    ["python3", os.path.expanduser("~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py"),
+     "--action", "screenshot", "--args", "{}"],
+    capture_output=True, text=True, timeout=120
+)
+data = json.loads(result.stdout)
+# data = {"type": "image", "data": "<base64>", "mimeType": "image/png"}
+with open("screenshot.png", "wb") as f:
+    f.write(base64.b64decode(data["data"]))
+print("截图已保存到 screenshot.png")
+```
+
+### 4. 用 eval 提取页面正文
+
+```bash
+SCRIPT=~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py
+
+python3 $SCRIPT --action open --args '{"url":"https://example.com/article"}'
+python3 $SCRIPT --action eval \
+  --args '{"script":"document.querySelector(\"article\").innerText"}'
+```
+
+---
+
+## 深入文档
+
+| 文档 | 说明 |
+|---|---|
+| [references/api.md](references/api.md) | 完整参数表、daemon REST 协议、`since` 增量查询、故障排查 |
+| [references/platforms.md](references/platforms.md) | 各平台操作速查：Twitter、Reddit、小红书、微博、B站、知乎等 12 个平台完整示例 |
+| [references/remote-ops.md](references/remote-ops.md) | 远程主机管理：启动命令、断联修复、故障排查 |

--- a/skills/bb-browser-remote/references/api.md
+++ b/skills/bb-browser-remote/references/api.md
@@ -1,0 +1,230 @@
+# bb-browser Daemon REST API 参考
+
+---
+
+## 环境变量
+
+| 环境变量 | 默认值 | 说明 |
+|---|---|---|
+| `BB_DAEMON_TOKEN` | `my-secret` | Bearer token |
+| `BB_DAEMON_URL` | `http://10.27.6.105:19824` | daemon 端点完整地址 |
+
+---
+
+## 端点 & 认证
+
+```
+POST ${BB_DAEMON_URL}/command   → 浏览器操作
+POST ${BB_DAEMON_URL}/site      → site adapter 命令
+GET  ${BB_DAEMON_URL}/status    → daemon 健康检查
+
+Authorization: Bearer ${BB_DAEMON_TOKEN}
+Content-Type: application/json
+```
+
+每次调用是独立的 HTTP 请求，无需预先建立连接或维持会话。
+
+---
+
+## POST /command — 浏览器操作
+
+请求格式：
+```json
+{
+  "id": "<uuid>",
+  "action": "<动作名>",
+  ...其他参数
+}
+```
+
+响应格式：
+```json
+{
+  "id": "<uuid>",
+  "success": true,
+  "data": { ... }
+}
+```
+
+失败时：
+```json
+{
+  "id": "<uuid>",
+  "success": false,
+  "error": "错误描述",
+  "hint": "解决提示（可选）"
+}
+```
+
+`call_daemon.py` 的 `browser_command()` 已自动处理错误与解包，正常情况直接使用脚本即可。
+
+---
+
+## POST /site — Site Adapter 命令
+
+请求格式：
+```json
+{
+  "command": "run",
+  "name": "twitter/search",
+  "args": ["Claude Code"],
+  "namedArgs": {},
+  "tab": "c416"
+}
+```
+
+响应格式：
+```json
+{
+  "success": true,
+  "data": { ... }
+}
+```
+
+支持的 command 值：
+
+| command | 说明 | 必填字段 |
+|---------|------|---------|
+| `list` | 列出所有 adapter | — |
+| `search` | 搜索 adapter | `query` |
+| `info` | 查看 adapter 详情 | `name` |
+| `recommend` | 基于历史推荐 | — |
+| `run` | 运行 adapter | `name` |
+| `update` | 更新社区 adapter 库 | — |
+
+---
+
+## GET /status — daemon 健康检查
+
+```bash
+python3 ~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py --status
+```
+
+响应：
+```json
+{
+  "running": true,
+  "cdpConnected": true,
+  "uptime": 1234,
+  "tabs": [...]
+}
+```
+
+---
+
+## 完整动作列表（POST /command）
+
+> 所有动作均支持可选的 `tabId` 参数（短 ID，如 `"c416"`），省略时操作当前活动标签页。
+
+### 导航类
+
+| action | 必填参数 | 可选参数 |
+|--------|---------|---------|
+| `open` | `url` | `tabId` |
+| `back` | — | `tabId` |
+| `forward` | — | `tabId` |
+| `refresh` | — | `tabId` |
+| `close` | — | `tabId` |
+
+### 观察类
+
+| action | 必填参数 | 可选参数 |
+|--------|---------|---------|
+| `snapshot` | — | `interactive`(bool), `compact`(bool), `maxDepth`(int), `selector`(CSS), `tabId` |
+| `screenshot` | — | `tabId` |
+| `get` | `attribute`（`text`/`url`/`title`/`value`/`html`） | `ref`（指定元素，省略则取页面级值）, `tabId` |
+
+### 交互类
+
+| action | 必填参数 | 可选参数 |
+|--------|---------|---------|
+| `click` | `ref` | `tabId` |
+| `hover` | `ref` | `tabId` |
+| `fill` | `ref`, `text` | `tabId` |
+| `type` | `ref`, `text` | `tabId` |
+| `check` | `ref` | `tabId` |
+| `uncheck` | `ref` | `tabId` |
+| `select` | `ref`, `value` | `tabId` |
+| `press` | `key`（见下方格式说明） | `tabId` |
+| `scroll` | `direction`（`up`/`down`/`left`/`right`） | `pixels`（默认 300）, `tabId` |
+| `eval` | `script` | `tabId` |
+
+### 系统类
+
+| action | 必填参数 | 可选参数 |
+|--------|---------|---------|
+| `wait` | — | `ms`（默认 1000）, `tabId` |
+| `dialog` | `dialogResponse`（`accept`/`dismiss`） | `promptText`（prompt 类型时的输入值）, `tabId` |
+| `frame` | `selector`（CSS 选择器） | `tabId` |
+| `frame_main` | — | `tabId` |
+
+### 标签页类
+
+| action | 必填参数 | 可选参数 |
+|--------|---------|---------|
+| `tab_list` | — | — |
+| `tab_new` | — | `url`（默认 about:blank） |
+| `tab_select` | — | `tabId`（短 ID）, `index`（0-based） |
+| `tab_close` | — | `tabId`（短 ID）, `index`（0-based） |
+
+### 网络/观测类
+
+| action | 必填参数 | 可选参数 |
+|--------|---------|---------|
+| `network` | — | `networkCommand`（`requests`/`clear`/`route`/`unroute`，默认 `requests`）, `filter`(URL 关键词), `since`, `method`, `status`, `limit`, `withBody`(bool), `tabId` |
+| `console` | — | `consoleCommand`（`get`/`clear`，默认 `get`）, `filter`, `since`, `limit`, `tabId` |
+| `errors` | — | `errorsCommand`（`get`/`clear`，默认 `get`）, `filter`, `since`, `limit`, `tabId` |
+| `trace` | `traceCommand`（`start`/`stop`/`status`） | `tabId` |
+| `history` | `historyCommand`（`search`/`domains`） | `query`（search 时使用）, `days`（默认 30） |
+
+---
+
+## 参数说明
+
+### `since` 增量查询（network / console / errors）
+
+- `"last_action"` — 返回上次操作之后的新事件
+- 数字（seq 序号）— 返回该序号之后的事件
+- 响应中包含 `cursor` 字段，可作为下次查询的 `since` 值
+
+```bash
+SCRIPT=~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py
+
+# 第一次查询
+python3 $SCRIPT --action network --args '{}'
+# 返回 data: {"networkRequests": [...], "cursor": 42}
+
+# 增量查询（只返回新增请求）
+python3 $SCRIPT --action network --args '{"since": 42}'
+```
+
+### `tabId` 短 ID
+
+- 格式：4 位以上十六进制字符串，如 `"c416"`
+- 来源：`tab_list`、`open`、`tab_new` 的响应 `data.tab` 字段
+- 省略时操作当前活动标签页
+
+### `press` 按键格式
+
+- 单键：`"Enter"`、`"Tab"`、`"Escape"`、`"ArrowDown"`
+- 组合键：`"Control+a"`、`"Shift+Tab"`、`"Meta+r"`
+- daemon 会自动拆分修饰键，无需手动分拆
+
+### `screenshot` 返回格式
+
+`call_daemon.py` 已自动转换，直接输出：
+```json
+{"type": "image", "data": "<base64>", "mimeType": "image/png"}
+```
+
+---
+
+## 故障排查
+
+| 错误 | 原因 | 解决 |
+|------|------|------|
+| `Connection refused` / `timed out` | daemon 未启动或网络不通 | 确认远程主机 `bb-browser daemon` 进程在运行；检查防火墙 |
+| `401 Unauthorized` | token 错误 | 核对 `BB_DAEMON_TOKEN` 是否与远程启动时一致 |
+| `503` / `Chrome not connected` | Chrome 未连接到 daemon | 重启远程 `bb-browser daemon` |
+| `Tab not found` | tab ID 无效或标签已关闭 | 重新用 `tab_list` 获取当前 tab 列表 |
+| `Command timeout` | 操作耗时超过 30s | 检查页面是否卡死；`--timeout` 参数无法突破 daemon 内部 30s 硬限制 |

--- a/skills/bb-browser-remote/references/platforms.md
+++ b/skills/bb-browser-remote/references/platforms.md
@@ -1,0 +1,176 @@
+# 各平台操作速查
+
+通过 `--site run` 调用，完整格式：
+
+```bash
+SCRIPT=~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py
+
+python3 $SCRIPT --site run --args '{"name":"平台/命令","args":["参数1","参数2"]}'
+```
+
+> 不确定某平台支持哪些命令或参数格式，先用 `site info` 查询：
+> ```bash
+> python3 $SCRIPT --site info --args '{"name":"twitter/search"}'
+> ```
+
+---
+
+## 🐦 Twitter/X
+
+```bash
+python3 $SCRIPT --site run --args '{"name":"twitter/for_you"}'
+python3 $SCRIPT --site run --args '{"name":"twitter/following"}'
+python3 $SCRIPT --site run --args '{"name":"twitter/search","args":["关键词"]}'
+python3 $SCRIPT --site run --args '{"name":"twitter/post","args":["推文内容"]}'
+python3 $SCRIPT --site run --args '{"name":"twitter/tweets","args":["用户名"]}'
+python3 $SCRIPT --site run --args '{"name":"twitter/notifications"}'
+python3 $SCRIPT --site run --args '{"name":"twitter/bookmarks"}'
+```
+
+## 🌸 小红书
+
+```bash
+python3 $SCRIPT --site run --args '{"name":"xiaohongshu/feed"}'
+python3 $SCRIPT --site run --args '{"name":"xiaohongshu/search","args":["关键词"]}'
+python3 $SCRIPT --site run --args '{"name":"xiaohongshu/note","args":["笔记ID"]}'
+python3 $SCRIPT --site run --args '{"name":"xiaohongshu/comments","args":["笔记ID"]}'
+python3 $SCRIPT --site run --args '{"name":"xiaohongshu/me"}'
+```
+
+## 📌 Pinterest
+
+```bash
+python3 $SCRIPT --site run --args '{"name":"pinterest/boards"}'
+
+# 发 Pin（先打开创建页确保登录态）
+python3 $SCRIPT --action open --args '{"url":"https://www.pinterest.com/pin-creation-tool/"}'
+python3 $SCRIPT --site run --args '{"name":"pinterest/post","args":["图片URL","Board名称","标题","描述","跳转链接"]}'
+```
+
+## 🎬 YouTube
+
+```bash
+python3 $SCRIPT --site run --args '{"name":"youtube/feed"}'
+python3 $SCRIPT --site run --args '{"name":"youtube/search","args":["关键词"]}'
+python3 $SCRIPT --site run --args '{"name":"youtube/video","args":["视频ID"]}'
+python3 $SCRIPT --site run --args '{"name":"youtube/post","args":["内容"]}'
+```
+
+## 🌐 微博
+
+```bash
+python3 $SCRIPT --site run --args '{"name":"m_weibo/hot"}'
+python3 $SCRIPT --site run --args '{"name":"m_weibo/post","args":["内容"]}'
+python3 $SCRIPT --site run --args '{"name":"m_weibo/search","args":["关键词"]}'
+python3 $SCRIPT --site run --args '{"name":"m_weibo/me"}'
+```
+
+## 👾 Reddit
+
+```bash
+# 热帖
+python3 $SCRIPT --site run --args '{"name":"reddit/hot","args":[]}'
+python3 $SCRIPT --site run --args '{"name":"reddit/hot","args":["LocalLLaMA"]}'
+
+# 搜索（关键词、subreddit、排序、时间范围、数量）
+python3 $SCRIPT --site run --args '{"name":"reddit/search","args":["关键词","LocalLLaMA","top","month","20"]}'
+
+# 帖子评论树（基础版）
+python3 $SCRIPT --site run --args '{"name":"reddit/thread","args":["https://www.reddit.com/r/LocalLLaMA/comments/xxx/"]}'
+
+# 帖子完整内容（增强版）— 支持相册图片、视频、转帖展开
+# 返回：post.selftext（完整正文）、post.images（图片列表含URL+尺寸）、post.video（视频URL）、post.crosspost_from（转帖原文）、comments（含创建时间）
+python3 $SCRIPT --site run --args '{"name":"reddit/thread_full","args":["https://www.reddit.com/r/rednote/comments/xxx/"]}'
+
+# 用户信息
+python3 $SCRIPT --site run --args '{"name":"reddit/me","args":[]}'
+
+# 查询 flair（发帖前先查）
+python3 $SCRIPT --site run --args '{"name":"reddit/flairs","args":["LocalLLaMA"]}'
+
+# 发文字帖
+python3 $SCRIPT --site run --args '{"name":"reddit/post_text","args":["subreddit","标题","正文内容"]}'
+python3 $SCRIPT --site run --args '{"name":"reddit/post_text","args":["subreddit","标题","正文"],"namedArgs":{"flair_id":"abc123"}}'
+python3 $SCRIPT --site run --args '{"name":"reddit/post_text","args":["subreddit","标题","正文"],"namedArgs":{"nsfw":"true"}}'
+
+# 发链接帖
+python3 $SCRIPT --site run --args '{"name":"reddit/post_link","args":["subreddit","标题","https://example.com"]}'
+python3 $SCRIPT --site run --args '{"name":"reddit/post_link","args":["subreddit","标题","https://example.com"],"namedArgs":{"text":"补充说明"}}'
+
+# 删帖
+python3 $SCRIPT --site run --args '{"name":"reddit/delete","args":["t3_xxxxxx"]}'
+python3 $SCRIPT --site run --args '{"name":"reddit/delete","args":["t3_aaa,t3_bbb,t3_ccc"]}'
+```
+
+**`reddit/post_text` 参数**
+
+| 参数 | 位置 | 必填 | 说明 |
+|---|---|---|---|
+| `subreddit` | `args[0]` | 是 | 不含 `r/` 前缀 |
+| `title` | `args[1]` | 是 | 最长 300 字符 |
+| `text` | `args[2]` | 否 | 正文（Markdown） |
+| `flair_id` | `namedArgs` | 否 | 由 `reddit/flairs` 返回 |
+| `flair_text` | `namedArgs` | 否 | 仅 `text_editable=true` 时生效 |
+| `nsfw` | `namedArgs` | 否 | `"true"` 标记 NSFW |
+| `spoiler` | `namedArgs` | 否 | `"true"` 标记剧透 |
+
+**`reddit/post_link` 参数**
+
+| 参数 | 位置 | 必填 | 说明 |
+|---|---|---|---|
+| `subreddit` | `args[0]` | 是 | 不含 `r/` 前缀 |
+| `title` | `args[1]` | 是 | 最长 300 字符 |
+| `url` | `args[2]` | 是 | 链接帖目标 URL |
+| `text` | `namedArgs` | 否 | 链接下方补充说明（Markdown） |
+| `flair_id` | `namedArgs` | 否 | 由 `reddit/flairs` 返回 |
+| `nsfw` | `namedArgs` | 否 | `"true"` 标记 NSFW |
+| `spoiler` | `namedArgs` | 否 | `"true"` 标记剧透 |
+
+## 📺 B站
+
+```bash
+python3 $SCRIPT --site run --args '{"name":"bilibili/popular"}'
+python3 $SCRIPT --site run --args '{"name":"bilibili/ranking"}'
+python3 $SCRIPT --site run --args '{"name":"bilibili/search","args":["关键词"]}'
+python3 $SCRIPT --site run --args '{"name":"bilibili/comments","args":["视频BV号"]}'
+```
+
+## 💡 知乎
+
+```bash
+python3 $SCRIPT --site run --args '{"name":"zhihu/hot"}'
+python3 $SCRIPT --site run --args '{"name":"zhihu/search","args":["关键词"]}'
+python3 $SCRIPT --site run --args '{"name":"zhihu/question","args":["问题ID"]}'
+```
+
+## 👨‍💻 GitHub
+
+```bash
+python3 $SCRIPT --site run --args '{"name":"github/repo","args":["owner/repo"]}'
+python3 $SCRIPT --site run --args '{"name":"github/issues","args":["owner/repo"]}'
+```
+
+## 🔍 搜索引擎
+
+```bash
+python3 $SCRIPT --site run --args '{"name":"google/search","args":["关键词"]}'
+python3 $SCRIPT --site run --args '{"name":"bing/search","args":["关键词"]}'
+python3 $SCRIPT --site run --args '{"name":"baidu/search","args":["关键词"]}'
+```
+
+## 💹 财经
+
+```bash
+python3 $SCRIPT --site run --args '{"name":"xueqiu/stock","args":["代码"]}'
+python3 $SCRIPT --site run --args '{"name":"xueqiu/hot"}'
+python3 $SCRIPT --site run --args '{"name":"yahoo-finance/quote","args":["TICKER"]}'
+```
+
+## 📰 资讯
+
+```bash
+python3 $SCRIPT --site run --args '{"name":"36kr/newsflash"}'
+python3 $SCRIPT --site run --args '{"name":"bbc/news"}'
+python3 $SCRIPT --site run --args '{"name":"toutiao/hot"}'
+python3 $SCRIPT --site run --args '{"name":"hackernews/top"}'
+```

--- a/skills/bb-browser-remote/references/remote-ops.md
+++ b/skills/bb-browser-remote/references/remote-ops.md
@@ -1,0 +1,53 @@
+# 远程主机管理与故障排查
+
+## 启动服务
+
+在远程主机上执行以下命令，启动 Edge 浏览器和 bb-browser daemon：
+
+```bash
+"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" \
+  --remote-debugging-port="${BB_CHROME_PORT:-19825}" \
+  --user-data-dir="$HOME/.bb-browser/browser/user-data" \
+  --no-first-run --no-default-browser-check about:blank \
+  > /dev/null 2>&1 &
+sleep 3
+bb-browser daemon \
+  --host 0.0.0.0 \
+  --port "${BB_DAEMON_PORT:-19824}" \
+  --token "${BB_DAEMON_TOKEN:-my-secret}" \
+  --cdp-port "${BB_CHROME_PORT:-19825}" &
+```
+
+**环境变量说明：**
+
+| 变量 | 默认值 | 说明 |
+|---|---|---|
+| `BB_DAEMON_TOKEN` | `my-secret` | Bearer token |
+| `BB_DAEMON_PORT` | `19824` | daemon 监听端口 |
+| `BB_CHROME_PORT` | `19825` | Chrome 远程调试端口（CDP） |
+
+## 验证连接
+
+```bash
+python3 ~/.openclaw/skills/bb-browser-remote/scripts/call_daemon.py --status
+```
+
+## 断联修复
+
+```bash
+# 端口被占用时，杀掉残留进程后重启 daemon
+lsof -ti:"${BB_DAEMON_PORT:-19824}" | xargs kill -9
+bb-browser daemon
+```
+
+## 故障排查
+
+| 错误 | 原因 | 解决 |
+|---|---|---|
+| `Chrome is not connected` | daemon 未连 Chrome | `lsof -ti:"${BB_DAEMON_PORT:-19824}" \| xargs kill -9 && bb-browser daemon` |
+| `EADDRINUSE 19824` | 端口残留 | `lsof -ti:"${BB_DAEMON_PORT:-19824}" \| xargs kill -9` |
+| `Connection refused` | daemon 未启动 | 在远程主机重新执行启动命令 |
+| `401 Unauthorized` | token 错误 | 确认 `BB_DAEMON_TOKEN` 与服务端一致 |
+| `Missing TwitterUserNotSuspended` | Twitter 登录态失效 | 在远程浏览器重新登录 x.com |
+| CAPTCHA 触发 | Reddit 账号被标记 | 在远程浏览器手动发一次帖完成验证 |
+| 代理干扰 | OpenClaw 服务器有 HTTP 代理 | 脚本已自动绕过，无需手动处理 |

--- a/skills/bb-browser-remote/scripts/call_daemon.py
+++ b/skills/bb-browser-remote/scripts/call_daemon.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""
+bb-browser daemon 客户端
+
+直接调用 daemon REST API：
+  POST /command  → 所有浏览器操作（open/snapshot/click/eval/...）
+  POST /site     → site adapter（run/list/info/recommend/update/search）
+  GET  /status   → daemon 健康检查
+
+用法:
+  python3 call_daemon.py --action open --args '{"url":"https://x.com"}'
+  python3 call_daemon.py --action snapshot --args '{"interactive":true}'
+  python3 call_daemon.py --action eval --args '{"script":"document.title"}'
+  python3 call_daemon.py --site run --args '{"name":"zhihu/hot"}'
+  python3 call_daemon.py --site list
+  python3 call_daemon.py --site info --args '{"name":"twitter/search"}'
+  python3 call_daemon.py --site run --args '{"name":"twitter/search","args":["Claude Code"]}'
+  python3 call_daemon.py --status
+
+环境变量（优先级：命令行 > 环境变量 > .env 文件 > 默认值）:
+  BB_DAEMON_URL    daemon 地址，默认 http://10.27.6.105:19824
+  BB_DAEMON_TOKEN  Bearer token，默认 my-secret
+
+注意：exec timeout 建议 ≥ 60 秒，截图/发帖等操作建议 120 秒。
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+import uuid
+import urllib.request
+import urllib.error
+
+# ── 配置 ──────────────────────────────────────────────────────────────────────
+
+# 自动加载 .env（优先级：环境变量 > .env > 默认值）
+_env_file = pathlib.Path(__file__).parent.parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        _line = _line.strip()
+        if _line and not _line.startswith("#") and "=" in _line:
+            _k, _v = _line.split("=", 1)
+            os.environ.setdefault(_k.strip(), _v.strip())
+
+DAEMON_URL = os.environ.get("BB_DAEMON_URL", "http://10.27.6.105:19824")
+DAEMON_TOKEN = os.environ.get("BB_DAEMON_TOKEN", "my-secret")
+
+
+def _apply_proxy_bypass() -> None:
+    """绕过代理，直连 daemon 主机。在 DAEMON_URL 最终确定后调用。"""
+    _host = DAEMON_URL.split("//")[-1].split(":")[0].split("/")[0]
+    os.environ.pop("http_proxy", None)
+    os.environ.pop("HTTP_PROXY", None)
+    _no_proxy = os.environ.get("no_proxy", "")
+    if _host not in _no_proxy:
+        os.environ["no_proxy"] = f"{_no_proxy},{_host}".strip(",")
+        os.environ["NO_PROXY"] = os.environ["no_proxy"]
+
+
+# ── HTTP 底层 ─────────────────────────────────────────────────────────────────
+
+def _post(endpoint: str, body: dict, timeout: int = 60) -> dict:
+    """发送 POST 请求，返回解析后的 JSON。失败直接 exit。"""
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        f"{DAEMON_URL}{endpoint}",
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {DAEMON_TOKEN}",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode(errors="replace"))
+    except urllib.error.HTTPError as e:
+        body_str = e.read().decode(errors="replace")
+        print(f"HTTP {e.code}: {body_str}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"连接失败: {e.reason}", file=sys.stderr)
+        print(
+            f"请确认远程主机 {DAEMON_URL} 可达，且 bb-browser daemon 已启动",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def _get(endpoint: str, timeout: int = 10) -> dict:
+    """发送 GET 请求，返回解析后的 JSON。"""
+    req = urllib.request.Request(
+        f"{DAEMON_URL}{endpoint}",
+        headers={"Authorization": f"Bearer {DAEMON_TOKEN}"},
+        method="GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode(errors="replace"))
+    except urllib.error.HTTPError as e:
+        body_str = e.read().decode(errors="replace")
+        print(f"HTTP {e.code}: {body_str}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"连接失败: {e.reason}", file=sys.stderr)
+        sys.exit(1)
+
+
+# ── 公共接口 ──────────────────────────────────────────────────────────────────
+
+def browser_command(action: str, args: dict | None = None, timeout: int = 60) -> dict:
+    """
+    调用浏览器命令（POST /command）。
+    返回完整 daemon 响应：{"success": true/false, "data": {...}, ...}
+    """
+    payload = {"id": str(uuid.uuid4()), "action": action, **(args or {})}
+    result = _post("/command", payload, timeout=timeout)
+    if not result.get("success"):
+        err = result.get("error", "Unknown error")
+        hint = result.get("hint", "")
+        print(f"命令失败: {err}", file=sys.stderr)
+        if hint:
+            print(f"提示: {hint}", file=sys.stderr)
+        sys.exit(1)
+    return result
+
+
+def site_command(command: str, args: dict | None = None, timeout: int = 60) -> dict:
+    """
+    调用 site adapter（POST /site）。
+    command: list | run | info | recommend | update | search
+    返回完整响应：{"success": true/false, "data": {...}}
+    """
+    payload = {"command": command, **(args or {})}
+    result = _post("/site", payload, timeout=timeout)
+    if not result.get("success"):
+        err = result.get("error", "Unknown error")
+        hint = result.get("hint", "")
+        print(f"site 命令失败: {err}", file=sys.stderr)
+        if hint:
+            print(f"提示: {hint}", file=sys.stderr)
+        sys.exit(1)
+    return result
+
+
+def daemon_status(timeout: int = 10) -> dict:
+    """获取 daemon 状态（GET /status）。"""
+    return _get("/status", timeout=timeout)
+
+
+# ── CLI 入口 ──────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="bb-browser daemon 客户端",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+示例:
+  %(prog)s --action open --args '{"url":"https://x.com"}'
+  %(prog)s --action snapshot --args '{"interactive":true}'
+  %(prog)s --action eval --args '{"script":"document.title"}'
+  %(prog)s --action click --args '{"ref":"e3","tabId":"c416"}'
+  %(prog)s --site run --args '{"name":"zhihu/hot"}'
+  %(prog)s --site run --args '{"name":"twitter/search","args":["Claude"]}'
+  %(prog)s --site list
+  %(prog)s --site info --args '{"name":"twitter/search"}'
+  %(prog)s --status
+""",
+    )
+    parser.add_argument("--action", help="浏览器命令 action（open/snapshot/click/fill/eval/...）")
+    parser.add_argument("--site", help="site adapter 子命令（run/list/info/recommend/update/search）")
+    parser.add_argument("--args", default="{}", help="JSON 参数字符串（默认 {}）")
+    parser.add_argument("--timeout", type=int, default=60, help="请求超时秒数（默认 60）")
+    parser.add_argument("--status", action="store_true", help="查看 daemon 状态")
+    parser.add_argument("--url", help="覆盖 daemon URL（优先于环境变量）")
+    parser.add_argument("--token", help="覆盖 Bearer token（优先于环境变量）")
+    opts = parser.parse_args()
+
+    global DAEMON_URL, DAEMON_TOKEN
+    if opts.url:
+        DAEMON_URL = opts.url
+    if opts.token:
+        DAEMON_TOKEN = opts.token
+    # 在 URL 最终确定后再设置代理绕过（命令行 --url 优先于 .env）
+    _apply_proxy_bypass()
+
+    try:
+        params = json.loads(opts.args)
+    except json.JSONDecodeError as e:
+        print(f"参数 JSON 解析失败: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if opts.status:
+        result = daemon_status(timeout=opts.timeout)
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return
+
+    if opts.action:
+        result = browser_command(opts.action, params, timeout=opts.timeout)
+        # 对于 screenshot 特殊处理：直接输出 image 结构让调用方处理 base64
+        data = result.get("data", {})
+        if opts.action == "screenshot" and isinstance(data, dict) and "dataUrl" in data:
+            data_url = data["dataUrl"]
+            b64 = data_url.replace("data:image/png;base64,", "") if isinstance(data_url, str) else ""
+            print(json.dumps({"type": "image", "data": b64, "mimeType": "image/png"}, ensure_ascii=False))
+        else:
+            print(json.dumps(data if data is not None else result, ensure_ascii=False, indent=2))
+        return
+
+    if opts.site:
+        result = site_command(opts.site, params, timeout=opts.timeout)
+        data = result.get("data")
+        print(json.dumps(data if data is not None else result, ensure_ascii=False, indent=2))
+        return
+
+    parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/start-bb-browser.sh
+++ b/start-bb-browser.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+BB_DAEMON_TOKEN="${BB_DAEMON_TOKEN:-my-secret}"
+BB_DAEMON_PORT="${BB_DAEMON_PORT:-19824}"
+BB_CHROME_PORT="${BB_CHROME_PORT:-19825}"
+
+# 清理旧进程
+pkill -f "bb-browser" 2>/dev/null || true
+sleep 2
+
+# 启动浏览器
+"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" \
+  --remote-debugging-port="$BB_CHROME_PORT" \
+  --user-data-dir="$HOME/.bb-browser/browser/user-data" \
+  --no-first-run --no-default-browser-check \
+  about:blank > /dev/null 2>&1 &
+
+sleep 3
+
+# 启动 daemon（自动发现 Chrome，对外监听供 skill 直连）
+bb-browser daemon \
+  --host 0.0.0.0 \
+  --port "$BB_DAEMON_PORT" \
+  --token "$BB_DAEMON_TOKEN" \
+  --cdp-port "$BB_CHROME_PORT" &
+DAEMON_PID=$!
+
+echo "   bb-browser started:"
+echo "   Chrome CDP:  127.0.0.1:$BB_CHROME_PORT"
+echo "   Daemon HTTP: 0.0.0.0:$BB_DAEMON_PORT (token: $BB_DAEMON_TOKEN)"
+echo "   Daemon PID:  $DAEMON_PID"
+echo ""
+echo "   skill .env:"
+echo "     BB_DAEMON_URL=http://<your-ip>:$BB_DAEMON_PORT"
+echo "     BB_DAEMON_TOKEN=$BB_DAEMON_TOKEN"
+
+# 保持脚本运行，Ctrl+C 时优雅关闭
+trap "kill -9 $DAEMON_PID 2>/dev/null; exit" SIGINT SIGTERM
+
+wait


### PR DESCRIPTION
## Background

bb-browser currently runs as a local daemon, but AI agents (e.g. OpenClaw running on a remote machine) had no standardized way to call it — users had to manually craft curl commands or write their own scripts.

This PR makes bb-browser remotely accessible as a first-class skill by:

1. Adding a `POST /site` endpoint to the daemon HTTP server, proxying site adapter commands to the CLI
2. Providing `call_daemon.py` — a single-file Python client that wraps all daemon REST calls with env-based config (`BB_DAEMON_TOKEN`, `BB_DAEMON_URL`)
3. Adding `start-bb-browser.sh` — a startup script that launches Chrome + daemon with token/host/port config and prints the `.env` values needed by the skill
4. Adding the `bb-browser-remote` skill (`SKILL.md` + `references/`) with full API reference, platform examples, and remote ops guide

## Changes

- `packages/daemon/src/http-server.ts` — add `POST /site` endpoint
- `skills/bb-browser-remote/scripts/call_daemon.py` — unified HTTP client for daemon REST API
- `skills/bb-browser-remote/SKILL.md` — skill entry point for AI agents
- `skills/bb-browser-remote/references/api.md` — full action/parameter reference
- `skills/bb-browser-remote/references/platforms.md` — platform-specific examples
- `skills/bb-browser-remote/references/remote-ops.md` — startup, reconnect, troubleshooting
- `start-bb-browser.sh` — one-shot daemon startup script

## How to Test

```bash
# On the host machine: start Chrome + daemon
BB_DAEMON_TOKEN=test-token BB_DAEMON_PORT=19824 ./start-bb-browser.sh

# From any machine with network access: verify connectivity
BB_DAEMON_TOKEN=test-token BB_DAEMON_URL=http://<host-ip>:19824 \
  python3 skills/bb-browser-remote/scripts/call_daemon.py --status

# List available site adapters
python3 skills/bb-browser-remote/scripts/call_daemon.py --site list
```
