### PR TITLE
fix(snapshot): clean up stale highlight overlays before each snapshot

### DIFF
--- a/packages/shared/buildDomTree.js
+++ b/packages/shared/buildDomTree.js
@@ -15,6 +15,16 @@ window.buildDomTree = (
 
   let highlightIndex = startHighlightIndex; // Reset highlight index
 
+  const HIGHLIGHT_CONTAINER_ID = 'playwright-highlight-container';
+
+  // Clean up highlights from previous snapshot invocations
+  const oldContainer = document.getElementById(HIGHLIGHT_CONTAINER_ID);
+  if (oldContainer) oldContainer.remove();
+  if (window._highlightCleanupFunctions) {
+    window._highlightCleanupFunctions.forEach(fn => fn());
+    window._highlightCleanupFunctions = [];
+  }
+
   // Add caching mechanisms at the top level
   const DOM_CACHE = {
     boundingRects: new WeakMap(),
@@ -98,8 +108,6 @@ window.buildDomTree = (
   const DOM_HASH_MAP = {};
 
   const ID = { current: startId };
-
-  const HIGHLIGHT_CONTAINER_ID = 'playwright-highlight-container';
 
   // Add a WeakMap cache for XPath strings
   const xpathCache = new WeakMap();


### PR DESCRIPTION
  Closes #173

  ## Problem

  When running `snapshot -i` multiple times on a single page (common in
  SPAs with client-side navigation), old highlight overlays accumulate
  inside the `playwright-highlight-container`. The container is reused
  across invocations but never cleared, so previous highlight boxes and
  their scroll/resize event listeners pile up.
snapshot 1: 
<img width="1920" height="993" alt="image" src="https://github.com/user-attachments/assets/066cba30-7b71-4cd1-a9c0-95f43b5a1894" />

snapshot 2:
<img width="1920" height="993" alt="image" src="https://github.com/user-attachments/assets/6dd9834d-051f-4f9a-94db-6333a6b51a37" />
twitter space is closed yet old highlight boxes remains 

  ## Solution

  At the top of `buildDomTree()`, remove the existing highlight container
  and run all stored cleanup functions before building the new tree. This
  ensures each snapshot starts clean regardless of how many times it has
  been called on the same page.

  Also i moved the `HIGHLIGHT_CONTAINER_ID` constant declaration earlier in
  the function 

## After fix: stale highlights cleaned up on re-snapshot
snapshot 1: 
<img width="1920" height="993" alt="image" src="https://github.com/user-attachments/assets/c88c0b74-220a-49a5-82ea-559a1a019ec1" />

close twitter space

snapshot 2: 
<img width="1920" height="993" alt="image" src="https://github.com/user-attachments/assets/6e914ec6-9b3b-452d-b671-963728345915" />


