### PR TITLE
docs: fix GitHub Search site examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ An agent can now, in under a minute:
 # Cross-platform research on any topic
 bb-browser site arxiv/search "retrieval augmented generation"
 bb-browser site twitter/search "RAG"
-bb-browser site github search rag-framework
+bb-browser site github/search rag-framework
 bb-browser site stackoverflow/search "RAG implementation"
 bb-browser site zhihu/search "RAG"
 bb-browser site 36kr/newsflash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,7 +132,7 @@ bb-browser guide    # 完整教程
 # 跨平台调研任何话题
 bb-browser site arxiv/search "retrieval augmented generation"
 bb-browser site twitter/search "RAG"
-bb-browser site github search rag-framework
+bb-browser site github/search rag-framework
 bb-browser site stackoverflow/search "RAG implementation"
 bb-browser site zhihu/search "RAG"
 bb-browser site 36kr/newsflash


### PR DESCRIPTION
Fixes #161

Correct the GitHub Search site examples in both README files to use the `github/search` site id.