### PR TITLE
fix(cli): keep MCP stdio parent alive

### DIFF
--- a/packages/cli/src/__tests__/daemon-startup.test.ts
+++ b/packages/cli/src/__tests__/daemon-startup.test.ts
@@ -15,11 +15,12 @@
 
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { spawn, execSync } from "node:child_process";
-import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdirSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import http from "node:http";
+import { shouldExitAfterMain } from "../lifecycle.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -422,5 +423,25 @@ describe("CDP 503 error includes diagnostics", () => {
     } finally {
       await new Promise<void>(resolve => fakeCdp.close(() => resolve()));
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MCP stdio lifecycle
+// ---------------------------------------------------------------------------
+
+describe("MCP stdio lifecycle", () => {
+  it("does not exit the CLI parent immediately in --mcp mode", () => {
+    assert.equal(
+      shouldExitAfterMain(["node", "cli.js", "--mcp"]),
+      false,
+    );
+  });
+
+  it("keeps normal CLI commands exiting after main completes", () => {
+    assert.equal(
+      shouldExitAfterMain(["node", "cli.js", "snapshot"]),
+      true,
+    );
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -32,6 +32,7 @@ import { historyCommand } from "./commands/history.js";
 import { shutdownCommand, statusCommand } from "./commands/daemon.js";
 import { getDaemonPath } from "./daemon-manager.js";
 import { setJqExpression } from "./client.js";
+import { shouldExitAfterMain } from "./lifecycle.js";
 
 declare const __BB_BROWSER_VERSION__: string;
 
@@ -771,4 +772,8 @@ Full guide:        https://github.com/epiral/bb-sites/blob/main/SKILL.md`);
   }
 }
 
-main().then(() => process.exit(0));
+main().then(() => {
+  if (shouldExitAfterMain()) {
+    process.exit(0);
+  }
+});

--- a/packages/cli/src/lifecycle.ts
+++ b/packages/cli/src/lifecycle.ts
@@ -1,0 +1,3 @@
+export function shouldExitAfterMain(argv: string[] = process.argv): boolean {
+  return !argv.includes("--mcp");
+}


### PR DESCRIPTION
## Summary
- Keep the CLI parent process alive after launching `--mcp` so the stdio MCP connection is not closed immediately.
- Preserve the existing explicit exit behavior for normal CLI commands.
- Add lifecycle coverage for `--mcp` vs regular CLI execution.

Fixes #201

## Testing
- `npx pnpm@9.15.0 --filter @bb-browser/shared build`
- `npx pnpm@9.15.0 build:release`
- `npx eslint packages/cli/src/index.ts packages/cli/src/lifecycle.ts packages/cli/src/__tests__/daemon-startup.test.ts`
- `npx pnpm@9.15.0 --filter @bb-browser/cli exec tsx -e "import assert from 'node:assert/strict'; import { shouldExitAfterMain } from './src/lifecycle.ts'; assert.equal(shouldExitAfterMain(['node','cli.js','--mcp']), false); assert.equal(shouldExitAfterMain(['node','cli.js','snapshot']), true);"`
