### PR TITLE
fix(cli): daemon self-healing on CDP disconnect + cookie persistence

### DIFF
--- a/packages/cli/src/cdp-discovery.ts
+++ b/packages/cli/src/cdp-discovery.ts
@@ -177,6 +177,7 @@ export async function launchManagedBrowser(port: number = DEFAULT_CDP_PORT): Pro
     "--disable-features=Translate,MediaRouter",
     "--disable-session-crashed-bubble",
     "--hide-crash-restore-bubble",
+    "--use-mock-keychain",
     "about:blank",
   ];
 

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -1,4 +1,4 @@
-import { getDaemonStatus, stopDaemon } from "../daemon-manager.js";
+import { ensureDaemon, getDaemonStatus, stopDaemon } from "../daemon-manager.js";
 
 export interface DaemonOptions {
   json?: boolean;
@@ -14,7 +14,7 @@ export async function statusCommand(
       console.log(JSON.stringify({ running: false }));
     } else {
       console.log("Daemon not running");
-      console.log("\n\u{1F4A1} 启动: bb-browser tab list (自动启动) 或 bb-browser daemon (前台启动)");
+      console.log("\n\u{1F4A1} 启动: bb-browser daemon start");
     }
     return;
   }
@@ -55,6 +55,23 @@ export async function statusCommand(
     console.log("\n⚠️ Chrome 未连接。运行 bb-browser daemon stop && bb-browser tab list 重新启动");
   } else {
     console.log("\n\u{1F4A1} 停止: bb-browser daemon stop");
+  }
+}
+
+export async function startCommand(
+  options: DaemonOptions = {}
+): Promise<void> {
+  await ensureDaemon();
+  const status = await getDaemonStatus();
+  if (options.json) {
+    console.log(JSON.stringify(status, null, 2));
+  } else {
+    console.log("Daemon started");
+    if (status) {
+      console.log(`CDP connected:  ${status.cdpConnected ? "yes" : "no"}`);
+      const tabs = status.tabs as Array<{ shortId: string }> | undefined;
+      console.log(`Tabs:           ${tabs?.length ?? 0}`);
+    }
   }
 }
 

--- a/packages/cli/src/commands/daemon.ts
+++ b/packages/cli/src/commands/daemon.ts
@@ -14,6 +14,7 @@ export async function statusCommand(
       console.log(JSON.stringify({ running: false }));
     } else {
       console.log("Daemon not running");
+      console.log("\n\u{1F4A1} 启动: bb-browser tab list (自动启动) 或 bb-browser daemon (前台启动)");
     }
     return;
   }
@@ -48,6 +49,12 @@ export async function statusCommand(
     }
   } else {
     console.log("\nNo tabs");
+  }
+
+  if (status.cdpConnected === false) {
+    console.log("\n⚠️ Chrome 未连接。运行 bb-browser daemon stop && bb-browser tab list 重新启动");
+  } else {
+    console.log("\n\u{1F4A1} 停止: bb-browser daemon stop");
   }
 }
 

--- a/packages/cli/src/daemon-manager.ts
+++ b/packages/cli/src/daemon-manager.ts
@@ -59,14 +59,15 @@ export function getDaemonPath(): string {
  */
 export async function ensureDaemon(): Promise<void> {
   if (daemonReady && cachedInfo) {
-    // Quick re-check: is it still alive?
+    // Quick re-check: is it still alive and CDP connected?
     try {
-      await httpJson<{ running: boolean }>("GET", "/status", cachedInfo, undefined, 2000);
-      return;
-    } catch {
-      daemonReady = false;
-      cachedInfo = null;
-    }
+      const status = await httpJson<{ running?: boolean; cdpConnected?: boolean }>("GET", "/status", cachedInfo, undefined, 2000);
+      if (status.running && status.cdpConnected !== false) {
+        return;
+      }
+    } catch {}
+    daemonReady = false;
+    cachedInfo = null;
   }
 
   // Try reading existing daemon.json and checking if daemon is alive
@@ -78,11 +79,16 @@ export async function ensureDaemon(): Promise<void> {
       info = null;
     } else {
       try {
-        const status = await httpJson<{ running?: boolean }>("GET", "/status", info, undefined, 2000);
-        if (status.running) {
+        const status = await httpJson<{ running?: boolean; cdpConnected?: boolean }>("GET", "/status", info, undefined, 2000);
+        if (status.running && status.cdpConnected !== false) {
           cachedInfo = info;
           daemonReady = true;
           return;
+        }
+        if (status.running && status.cdpConnected === false) {
+          await stopDaemon();
+          await deleteDaemonJson();
+          info = null;
         }
       } catch {
         // Daemon process exists but HTTP not responding — fall through to spawn

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,7 +29,7 @@ import { traceCommand } from "./commands/trace.js";
 import { fetchCommand } from "./commands/fetch.js";
 import { siteCommand } from "./commands/site.js";
 import { historyCommand } from "./commands/history.js";
-import { shutdownCommand, statusCommand } from "./commands/daemon.js";
+import { shutdownCommand, startCommand, statusCommand } from "./commands/daemon.js";
 import { getDaemonPath } from "./daemon-manager.js";
 import { setJqExpression } from "./client.js";
 
@@ -91,7 +91,7 @@ bb-browser - AI Agent 浏览器自动化工具
   errors [--clear]             查看/清空 JS 错误
   trace start|stop|status      录制用户操作
   history search|domains       查看浏览历史
-  daemon [status|stop] [opts]  前台运行或管理 daemon
+  daemon [start|status|stop]   管理 daemon（start: 后台启动）
 
 选项：
   --json               以 JSON 格式输出
@@ -438,6 +438,10 @@ async function main(): Promise<void> {
         }
         if (daemonSubcommand === "stop" || daemonSubcommand === "shutdown") {
           await shutdownCommand({ json: parsed.flags.json });
+          break;
+        }
+        if (daemonSubcommand === "start") {
+          await startCommand({ json: parsed.flags.json });
           break;
         }
 


### PR DESCRIPTION
## Summary

- **Daemon self-healing**: `ensureDaemon()` now checks `cdpConnected` from `/status`. When Chrome is killed and the daemon loses its CDP WebSocket, the stale daemon is automatically stopped and a fresh daemon+Chrome is spawned — instead of returning 503 on every subsequent command.
- **Status hints**: `bb-browser daemon status` now shows actionable next steps (how to start, how to stop, or how to recover from CDP disconnect).
- **Cookie persistence**: Adds `--use-mock-keychain` to managed Chrome launch args. On headless/remote machines (e.g. Mac Mini via SSH), macOS Keychain is inaccessible (`errSecInteractionNotAllowed`), preventing Chrome from encrypting and persisting cookies to disk. The mock keychain uses a fixed encryption key, bypassing the Keychain entirely. This is the same approach used by chromedp, Playwright, and Cypress.

## Test plan

- [x] `bb-browser daemon status` shows hint when not running
- [x] `bb-browser daemon status` shows stop hint when running
- [x] `pkill Chrome` → `bb-browser tab list` auto-recovers (no 503)
- [x] Mac Mini: cookies persist across Chrome restarts (Google login survives kill+restart)
- [x] Local: no regression, cookies still persist
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)