### PR TITLE
feat(shared): support BB_BROWSER_TIMEOUT env var

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -12,7 +12,7 @@ export const DAEMON_HOST = "127.0.0.1";
 export const SSE_HEARTBEAT_INTERVAL = 15000; // 15 秒
 
 /** 命令执行超时时间（毫秒） */
-export const COMMAND_TIMEOUT = 30000; // 30 秒
+export const COMMAND_TIMEOUT = Number(process.env.BB_BROWSER_TIMEOUT) || 30000; // 默认 30 秒，可通过环境变量覆盖
 
 /** SSE 重连延迟（毫秒） */
 export const SSE_RECONNECT_DELAY = 3000; // 3 秒


### PR DESCRIPTION
## Summary

Allow users to override the default command timeout via the `BB_BROWSER_TIMEOUT` environment variable, instead of having to modify the source code.

## Problem

When running site adapters that interact with LLM services (e.g., qwen/search), the SSE stream response can take 30–120 seconds depending on the query complexity. The current hardcoded 30-second timeout causes `Command timeout` errors for these long-running operations.

## Solution

Read `BB_BROWSER_TIMEOUT` from `process.env` with a fallback to the original 30000ms (30s), preserving backward compatibility.

## Usage
BB_BROWSER_TIMEOUT=120000 bb-browser site qwen/search "..."

## Changes

- `packages/shared/src/constants.ts`: `COMMAND_TIMEOUT` now reads from `process.env.BB_BROWSER_TIMEOUT`