### PR TITLE
feat: remote browser viewing via Clip Web UI

### DIFF
--- a/bin/bb-browser-provider.ts
+++ b/bin/bb-browser-provider.ts
@@ -67,6 +67,10 @@ const RECONNECT_DELAY_MS = 5000;
 const REGISTER_TIMEOUT_MS = 10000;
 const HEARTBEAT_INTERVAL_MS = 15000;
 
+const VIEWER_PORT = "3334";
+const VIEWER_API_BASE = `http://127.0.0.1:${VIEWER_PORT}`;
+let viewerProcess: ReturnType<typeof spawn> | null = null;
+
 const LOCAL_SITES_DIR = join(SHARED_DAEMON_DIR, "sites");
 const COMMUNITY_SITES_DIR = join(SHARED_DAEMON_DIR, "bb-sites");
 
@@ -140,6 +144,96 @@ async function daemonCommand(request: Request): Promise<Response> {
   if (!cachedDaemonInfo) cachedDaemonInfo = await readDaemonJson();
   if (!cachedDaemonInfo) throw new Error("No daemon.json found. Is the daemon running?");
   return httpJson<Response>("POST", "/command", cachedDaemonInfo, request, COMMAND_TIMEOUT);
+}
+
+// ---------------------------------------------------------------------------
+// Viewer sidecar management
+// ---------------------------------------------------------------------------
+
+function findViewerBinary(): string | null {
+  const localPath = join(SHARED_DAEMON_DIR, "bin", "bb-viewer");
+  if (existsSync(localPath)) return localPath;
+  // Fall back to PATH
+  return "bb-viewer";
+}
+
+async function ensureViewer(): Promise<void> {
+  if (viewerProcess && !viewerProcess.killed) {
+    try {
+      const resp = await fetch(`${VIEWER_API_BASE}/health`, { signal: AbortSignal.timeout(2000) });
+      if (resp.ok) return;
+    } catch {}
+    // Not healthy — kill and respawn
+    try { viewerProcess.kill(); } catch {}
+    viewerProcess = null;
+  }
+
+  const bin = findViewerBinary();
+  if (!bin) throw new Error("bb-viewer binary not found");
+
+  const cdpPort = cachedDaemonInfo?.cdpPort?.toString() || process.env.CDP_PORT || "9222";
+  const args = ["--api-only", "--cdp-port", cdpPort, "--port", VIEWER_PORT];
+
+  const turnUrl = process.env.TURN_URL;
+  const turnUser = process.env.TURN_USER;
+  const turnCred = process.env.TURN_CRED;
+  if (turnUrl) { args.push("--turn-url", turnUrl); }
+  if (turnUser) { args.push("--turn-user", turnUser); }
+  if (turnCred) { args.push("--turn-cred", turnCred); }
+
+  console.log(`${LOG_PREFIX} Spawning viewer: ${bin} ${args.join(" ")}`);
+  const child = spawn(bin, args, { stdio: ["ignore", "pipe", "pipe"] });
+  viewerProcess = child;
+
+  child.stdout?.on("data", (d: Buffer) => {
+    const lines = d.toString().trim().split("\n");
+    for (const line of lines) console.log(`${LOG_PREFIX} [viewer] ${line}`);
+  });
+  child.stderr?.on("data", (d: Buffer) => {
+    const lines = d.toString().trim().split("\n");
+    for (const line of lines) console.error(`${LOG_PREFIX} [viewer] ${line}`);
+  });
+  child.on("exit", (code) => {
+    console.log(`${LOG_PREFIX} [viewer] exited with code ${code}`);
+    if (viewerProcess === child) viewerProcess = null;
+  });
+
+  // Wait for health check
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 300));
+    try {
+      const resp = await fetch(`${VIEWER_API_BASE}/health`, { signal: AbortSignal.timeout(2000) });
+      if (resp.ok) {
+        console.log(`${LOG_PREFIX} Viewer ready at port ${VIEWER_PORT}`);
+        return;
+      }
+    } catch {}
+  }
+  throw new Error("Viewer did not become healthy in 10s");
+}
+
+function stopViewer(): void {
+  if (viewerProcess && !viewerProcess.killed) {
+    console.log(`${LOG_PREFIX} Stopping viewer`);
+    try { viewerProcess.kill(); } catch {}
+    viewerProcess = null;
+  }
+}
+
+async function viewerCommand(path: string, body?: unknown): Promise<unknown> {
+  await ensureViewer();
+  const url = `${VIEWER_API_BASE}${path}`;
+  const opts: RequestInit = {
+    method: body ? "POST" : "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+    signal: AbortSignal.timeout(15000),
+  };
+  const resp = await fetch(url, opts);
+  const text = await resp.text();
+  if (!resp.ok) throw new Error(`Viewer ${path} failed (${resp.status}): ${text}`);
+  try { return JSON.parse(text); } catch { return { output: text }; }
 }
 
 // ---------------------------------------------------------------------------
@@ -296,15 +390,66 @@ function buildPlatformClips(): PlatformClip[] {
 // ---------------------------------------------------------------------------
 
 const BROWSER_COMMANDS = COMMANDS.filter((c) => c.category !== "site");
-const BROWSER_COMMAND_NAMES = BROWSER_COMMANDS.map((c) => c.name);
+
+const VIEW_COMMANDS = [
+  {
+    name: "view.start",
+    description: "Start remote viewing: creates a WebRTC peer and returns offer SDP + ICE candidates",
+    inputSchema: JSON.stringify({ type: "object", properties: {}, additionalProperties: true }),
+  },
+  {
+    name: "view.answer",
+    description: "Complete WebRTC connection: accepts answer SDP + ICE candidates, starts video streaming",
+    inputSchema: JSON.stringify({
+      type: "object",
+      properties: {
+        answer_sdp: { type: "string", description: "Answer SDP from the remote peer" },
+        candidates: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              candidate: { type: "string" },
+              sdpMLineIndex: { type: "number" },
+            },
+            required: ["candidate", "sdpMLineIndex"],
+          },
+          description: "ICE candidates from the remote peer",
+        },
+      },
+      required: ["answer_sdp"],
+      additionalProperties: true,
+    }),
+  },
+  {
+    name: "view.close",
+    description: "Stop remote viewing and close the WebRTC peer",
+    inputSchema: JSON.stringify({ type: "object", properties: {}, additionalProperties: true }),
+  },
+];
+
+const BROWSER_COMMAND_NAMES = [
+  ...BROWSER_COMMANDS.map((c) => c.name),
+  "view.start",
+  "view.answer",
+  "view.close",
+];
 
 function buildClipRegistrations() {
-  const browserCommands = BROWSER_COMMANDS.map((cmd) => ({
-    name: cmd.name,
-    description: cmd.description,
-    input: JSON.stringify(zodToJsonSchema(cmd.args)),
-    output: JSON.stringify({ type: "object", additionalProperties: true }),
-  }));
+  const browserCommands = [
+    ...BROWSER_COMMANDS.map((cmd) => ({
+      name: cmd.name,
+      description: cmd.description,
+      input: JSON.stringify(zodToJsonSchema(cmd.args)),
+      output: JSON.stringify({ type: "object", additionalProperties: true }),
+    })),
+    ...VIEW_COMMANDS.map((cmd) => ({
+      name: cmd.name,
+      description: cmd.description,
+      input: cmd.inputSchema,
+      output: JSON.stringify({ type: "object", additionalProperties: true }),
+    })),
+  ];
 
   const platformClips = buildPlatformClips();
 
@@ -661,7 +806,13 @@ class HubBridge {
       const input = decodeInput(inv.input);
       let result: unknown;
 
-      if (clipName === BROWSER_CLIP_ALIAS) {
+      if (clipName === BROWSER_CLIP_ALIAS && command === "view.start") {
+        result = await viewerCommand("/peer/create");
+      } else if (clipName === BROWSER_CLIP_ALIAS && command === "view.answer") {
+        result = await viewerCommand("/peer/answer", input);
+      } else if (clipName === BROWSER_CLIP_ALIAS && command === "view.close") {
+        result = await viewerCommand("/peer/close");
+      } else if (clipName === BROWSER_CLIP_ALIAS) {
         result = await executeBrowserCommand(command, input);
       } else if (this.platformClipAliases.has(clipName)) {
         result = await executeSiteCommand(clipName, command, input);
@@ -806,8 +957,8 @@ function main(): void {
 
   const bridge = new HubBridge(hubUrl, platformClips);
 
-  process.on("SIGINT", () => { bridge.stop(); process.exit(0); });
-  process.on("SIGTERM", () => { bridge.stop(); process.exit(0); });
+  process.on("SIGINT", () => { stopViewer(); bridge.stop(); process.exit(0); });
+  process.on("SIGTERM", () => { stopViewer(); bridge.stop(); process.exit(0); });
   process.on("unhandledRejection", (r) => { console.error(`${LOG_PREFIX} Unhandled rejection: ${r instanceof Error ? r.message : r}`); });
   process.on("uncaughtException", (e) => { console.error(`${LOG_PREFIX} Uncaught exception: ${e instanceof Error ? e.message : e}`); });
 

--- a/bin/bb-browser-provider.ts
+++ b/bin/bb-browser-provider.ts
@@ -24,6 +24,9 @@ import {
   HeartbeatSchema,
   HubErrorSchema,
 } from "@pinixai/hub-client";
+// GetClipWebResultSchema is not re-exported from @pinixai/hub-client index;
+// import directly from the gen file via relative path to node_modules.
+import { GetClipWebResultSchema, type GetClipWebCommand } from "../node_modules/@pinixai/hub-client/src/gen/hub_pb.ts";
 import { COMMANDS } from "../packages/shared/src/commands.ts";
 import { COMMAND_TIMEOUT, generateId } from "../packages/shared/src/index.ts";
 import type { Request, Response } from "../packages/shared/src/protocol.ts";
@@ -459,7 +462,7 @@ function buildClipRegistrations() {
     version: CLIP_VERSION,
     domain: BROWSER_CLIP_DOMAIN,
     commands: browserCommands,
-    hasWeb: false,
+    hasWeb: true,
     dependencies: [],
     tokenProtected: false,
   });
@@ -780,7 +783,10 @@ class HubBridge {
           }
           case "invokeInput": break; // unary commands only
           case "pong": break;
-          case "getClipWebCommand": break; // no web assets
+          case "getClipWebCommand": {
+            void this.handleGetClipWeb(queue, msg.payload.value);
+            break;
+          }
           default: break;
         }
       }
@@ -835,6 +841,115 @@ class HubBridge {
       this.sendDataResult(queue, requestId, output, undefined);
     } catch (err) {
       this.sendDataResult(queue, requestId, undefined, err);
+    }
+  }
+
+  private async handleGetClipWeb(queue: AsyncMessageQueue<ProviderMessage>, cmd: GetClipWebCommand): Promise<void> {
+    const requestId = cmd.requestId?.trim();
+    if (!requestId) return;
+
+    try {
+      let filePath = cmd.path?.trim() || "";
+      // Default to view.html
+      if (!filePath || filePath === "/" || filePath === "index.html") filePath = "view.html";
+      // Strip leading slash
+      if (filePath.startsWith("/")) filePath = filePath.slice(1);
+
+      // Security: prevent directory traversal
+      if (filePath.includes("..") || filePath.startsWith("/")) {
+        throw new Error("Invalid path");
+      }
+
+      // Resolve relative to web/ directory alongside the source file
+      const currentDir = dirname(fileURLToPath(import.meta.url));
+      const webDir = resolve(currentDir, "../web");
+      const fullPath = join(webDir, filePath);
+
+      // Ensure the resolved path is within webDir
+      const resolvedFull = resolve(fullPath);
+      const resolvedWeb = resolve(webDir);
+      if (!resolvedFull.startsWith(resolvedWeb)) {
+        throw new Error("Invalid path");
+      }
+
+      const content = await readFileAsync(fullPath);
+
+      // Content type
+      const ext = extname(filePath).toLowerCase();
+      const MIME_MAP: Record<string, string> = {
+        ".html": "text/html; charset=utf-8",
+        ".js": "application/javascript; charset=utf-8",
+        ".mjs": "application/javascript; charset=utf-8",
+        ".css": "text/css; charset=utf-8",
+        ".json": "application/json; charset=utf-8",
+        ".svg": "image/svg+xml",
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+        ".ico": "image/x-icon",
+        ".woff": "font/woff",
+        ".woff2": "font/woff2",
+        ".ttf": "font/ttf",
+      };
+      const contentType = MIME_MAP[ext] || "application/octet-stream";
+
+      // ETag based on content length (simple)
+      const etag = `"${content.length.toString(16)}"`;
+
+      // Handle if-none-match
+      if (cmd.ifNoneMatch && cmd.ifNoneMatch === etag) {
+        queue.push(create(ProviderMessageSchema, {
+          payload: {
+            case: "getClipWebResult",
+            value: create(GetClipWebResultSchema, {
+              requestId,
+              notModified: true,
+              etag,
+              totalSize: BigInt(content.length),
+            }),
+          },
+        }));
+        return;
+      }
+
+      // Handle range requests (offset/length)
+      const offset = Number(cmd.offset || 0n);
+      const length = Number(cmd.length || 0n);
+      let slice: Uint8Array;
+      if (length > 0) {
+        slice = new Uint8Array(content.buffer, content.byteOffset + offset, Math.min(length, content.length - offset));
+      } else if (offset > 0) {
+        slice = new Uint8Array(content.buffer, content.byteOffset + offset);
+      } else {
+        slice = new Uint8Array(content);
+      }
+
+      queue.push(create(ProviderMessageSchema, {
+        payload: {
+          case: "getClipWebResult",
+          value: create(GetClipWebResultSchema, {
+            requestId,
+            content: slice,
+            contentType,
+            etag,
+            totalSize: BigInt(content.length),
+          }),
+        },
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const code = message === "Invalid path" ? "invalid_argument" : "not_found";
+      queue.push(create(ProviderMessageSchema, {
+        payload: {
+          case: "getClipWebResult",
+          value: create(GetClipWebResultSchema, {
+            requestId,
+            error: create(HubErrorSchema, { code, message }),
+          }),
+        },
+      }));
     }
   }
 

--- a/bin/bb-browser-provider.ts
+++ b/bin/bb-browser-provider.ts
@@ -44,6 +44,7 @@ import { execFile } from "node:child_process";
 import { join, dirname, resolve, relative, extname } from "node:path";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { createHmac } from "node:crypto";
 import type { z } from "zod";
 
 declare const process: {
@@ -150,6 +151,17 @@ async function daemonCommand(request: Request): Promise<Response> {
 }
 
 // ---------------------------------------------------------------------------
+// TURN ephemeral credentials (TURN REST API / RFC 7635 time-limited)
+// ---------------------------------------------------------------------------
+
+function generateTurnCredentials(secret: string, ttlSeconds = 86400): { username: string; password: string } {
+  const expiry = Math.floor(Date.now() / 1000) + ttlSeconds;
+  const username = `${expiry}:bbviewer`;
+  const password = createHmac("sha1", secret).update(username).digest("base64");
+  return { username, password };
+}
+
+// ---------------------------------------------------------------------------
 // Viewer sidecar management
 // ---------------------------------------------------------------------------
 
@@ -177,12 +189,18 @@ async function ensureViewer(): Promise<void> {
   const cdpPort = cachedDaemonInfo?.cdpPort?.toString() || process.env.CDP_PORT || "9222";
   const args = ["--api-only", "--cdp-port", cdpPort, "--port", VIEWER_PORT];
 
+  // Generate ephemeral TURN credentials (valid 24h). Both bb-viewer (Pion
+  // relay candidate gathering) and the frontend (WebRTC connection) use
+  // the same credentials. If the viewer runs >24h, it will be restarted
+  // with fresh credentials on the next view.start.
   const turnUrl = process.env.TURN_URL;
-  const turnUser = process.env.TURN_USER;
-  const turnCred = process.env.TURN_CRED;
-  if (turnUrl) { args.push("--turn-url", turnUrl); }
-  if (turnUser) { args.push("--turn-user", turnUser); }
-  if (turnCred) { args.push("--turn-cred", turnCred); }
+  const turnSecret = process.env.TURN_SECRET;
+  if (turnUrl && turnSecret) {
+    const { username, password } = generateTurnCredentials(turnSecret);
+    args.push("--turn-url", turnUrl, "--turn-user", username, "--turn-cred", password);
+  } else if (turnUrl) {
+    args.push("--turn-url", turnUrl);
+  }
 
   console.log(`${LOG_PREFIX} Spawning viewer: ${bin} ${args.join(" ")}`);
   const child = spawn(bin, args, { stdio: ["ignore", "pipe", "pipe"] });

--- a/packages/daemon/src/http-server.ts
+++ b/packages/daemon/src/http-server.ts
@@ -22,6 +22,8 @@ export interface HttpServerOptions {
   port?: number;
   token?: string;
   cdp: CdpConnection;
+  cdpHost?: string;
+  cdpPort?: number;
   onShutdown?: () => void;
 }
 
@@ -31,6 +33,8 @@ export class HttpServer {
   private readonly port: number;
   private readonly token: string | null;
   private readonly cdp: CdpConnection;
+  private readonly cdpHost: string | null;
+  private readonly cdpPort: number | null;
   private readonly onShutdown?: () => void;
   private startTime = 0;
 
@@ -39,6 +43,8 @@ export class HttpServer {
     this.port = options.port ?? DAEMON_PORT;
     this.token = options.token ?? null;
     this.cdp = options.cdp;
+    this.cdpHost = options.cdpHost ?? null;
+    this.cdpPort = options.cdpPort ?? null;
     this.onShutdown = options.onShutdown;
   }
 
@@ -183,6 +189,8 @@ export class HttpServer {
     this.sendJson(res, 200, {
       running: true,
       cdpConnected: this.cdp.connected,
+      cdpHost: this.cdpHost,
+      cdpPort: this.cdpPort,
       uptime: this.uptime,
       currentSeq: this.cdp.tabManager.currentSeq(),
       currentTargetId: this.cdp.currentTargetId,

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -121,6 +121,8 @@ interface DaemonInfo {
   host: string;
   port: number;
   token: string;
+  cdpHost: string;
+  cdpPort: number;
 }
 
 function writeDaemonJson(info: DaemonInfo): void {
@@ -228,6 +230,8 @@ async function main(): Promise<void> {
     port: options.port,
     token: options.token,
     cdp,
+    cdpHost: cdpEndpoint.host,
+    cdpPort: cdpEndpoint.port,
     onShutdown: shutdown,
   });
 
@@ -240,6 +244,8 @@ async function main(): Promise<void> {
     host: options.host,
     port: options.port,
     token: options.token,
+    cdpHost: cdpEndpoint.host,
+    cdpPort: cdpEndpoint.port,
   });
 
   console.error(

--- a/packages/shared/src/daemon-client.ts
+++ b/packages/shared/src/daemon-client.ts
@@ -26,6 +26,8 @@ export interface DaemonInfo {
   host: string;
   port: number;
   token: string;
+  cdpHost?: string;
+  cdpPort?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/view.html
+++ b/web/view.html
@@ -1,0 +1,392 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Remote Browser</title>
+<style>
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { height: 100%; overflow: hidden; background: #0a0a0a; color: #e0e0e0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace; }
+#app { display: flex; flex-direction: column; height: 100%; }
+#toolbar { display: flex; align-items: center; gap: 8px; padding: 6px 12px; background: #1a1a1a; border-bottom: 1px solid #2a2a2a; flex-shrink: 0; }
+#toolbar button { padding: 4px 14px; border: 1px solid #444; border-radius: 4px; background: #2a2a2a; color: #e0e0e0; cursor: pointer; font-size: 13px; }
+#toolbar button:hover { background: #3a3a3a; }
+#toolbar button.connected { border-color: #e55; background: #3a1a1a; }
+#status { font-size: 12px; color: #888; margin-left: auto; }
+#video-container { flex: 1; display: flex; align-items: center; justify-content: center; position: relative; overflow: hidden; background: #000; }
+video { max-width: 100%; max-height: 100%; object-fit: contain; background: #000; }
+#ime-input { position: fixed; top: -100px; left: -100px; width: 1px; height: 1px; opacity: 0; }
+</style>
+</head>
+<body>
+<div id="app">
+  <div id="toolbar">
+    <button id="btn-connect">Connect</button>
+    <span id="status">Disconnected</span>
+  </div>
+  <div id="video-container">
+    <video id="video" autoplay playsinline muted></video>
+  </div>
+</div>
+<textarea id="ime-input" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
+
+<script type="module">
+import { invoke } from "https://esm.sh/@pinixai/core@0.5.2/web";
+
+// --- State ---
+let pc = null;
+let dc = null;
+let connected = false;
+let videoEl = document.getElementById("video");
+let btnConnect = document.getElementById("btn-connect");
+let statusEl = document.getElementById("status");
+let imeInput = document.getElementById("ime-input");
+let videoContainer = document.getElementById("video-container");
+let isComposing = false;
+
+// --- UI ---
+function setStatus(text) { statusEl.textContent = text; }
+
+function setConnected(state) {
+  connected = state;
+  btnConnect.textContent = state ? "Disconnect" : "Connect";
+  btnConnect.classList.toggle("connected", state);
+  setStatus(state ? "Connected" : "Disconnected");
+}
+
+// --- Binary protocol helpers ---
+function packHeader(opcode, payloadLen) {
+  const buf = new ArrayBuffer(3 + payloadLen);
+  const view = new DataView(buf);
+  view.setUint8(0, opcode);
+  view.setUint16(1, payloadLen);
+  return { buf, view };
+}
+
+function sendMouseMove(x, y) {
+  if (!dc || dc.readyState !== "open") return;
+  const { buf, view } = packHeader(0x01, 4);
+  view.setUint16(3, x);
+  view.setUint16(5, y);
+  dc.send(buf);
+}
+
+function sendScroll(dx, dy) {
+  if (!dc || dc.readyState !== "open") return;
+  const { buf, view } = packHeader(0x02, 4);
+  view.setInt16(3, dx);
+  view.setInt16(5, dy);
+  dc.send(buf);
+}
+
+function sendKeyDown(keysym) {
+  if (!dc || dc.readyState !== "open") return;
+  const { buf, view } = packHeader(0x03, 4);
+  view.setUint32(3, keysym);
+  dc.send(buf);
+}
+
+function sendKeyUp(keysym) {
+  if (!dc || dc.readyState !== "open") return;
+  const { buf, view } = packHeader(0x04, 4);
+  view.setUint32(3, keysym);
+  dc.send(buf);
+}
+
+function sendButtonDown(button) {
+  if (!dc || dc.readyState !== "open") return;
+  const { buf, view } = packHeader(0x05, 1);
+  view.setUint8(3, button);
+  dc.send(buf);
+}
+
+function sendButtonUp(button) {
+  if (!dc || dc.readyState !== "open") return;
+  const { buf, view } = packHeader(0x06, 1);
+  view.setUint8(3, button);
+  dc.send(buf);
+}
+
+function sendInsertText(text) {
+  if (!dc || dc.readyState !== "open") return;
+  const encoded = new TextEncoder().encode(text);
+  const { buf, view } = packHeader(0x07, encoded.length);
+  new Uint8Array(buf).set(encoded, 3);
+  dc.send(buf);
+}
+
+// --- Keysym mapping ---
+const SPECIAL_KEYS = {
+  Backspace: 0xFF08, Tab: 0xFF09, Enter: 0xFF0D, Escape: 0xFF1B,
+  Delete: 0xFFFF, Home: 0xFF50, End: 0xFF57,
+  PageUp: 0xFF55, PageDown: 0xFF56,
+  ArrowLeft: 0xFF51, ArrowUp: 0xFF52, ArrowRight: 0xFF53, ArrowDown: 0xFF54,
+  ShiftLeft: 0xFFE1, ShiftRight: 0xFFE2,
+  ControlLeft: 0xFFE3, ControlRight: 0xFFE4,
+  AltLeft: 0xFFE9, AltRight: 0xFFEA,
+  MetaLeft: 0xFFEB, MetaRight: 0xFFEC,
+  CapsLock: 0xFFE5, NumLock: 0xFF7F, ScrollLock: 0xFF14,
+  Insert: 0xFF63, Pause: 0xFF13, PrintScreen: 0xFF61,
+  F1: 0xFFBE, F2: 0xFFBF, F3: 0xFFC0, F4: 0xFFC1,
+  F5: 0xFFC2, F6: 0xFFC3, F7: 0xFFC4, F8: 0xFFC5,
+  F9: 0xFFC6, F10: 0xFFC7, F11: 0xFFC8, F12: 0xFFC9,
+  Space: 0x0020,
+};
+
+function keyToKeysym(e) {
+  if (SPECIAL_KEYS[e.code]) return SPECIAL_KEYS[e.code];
+  if (SPECIAL_KEYS[e.key]) return SPECIAL_KEYS[e.key];
+  // Modifier keys by key name
+  if (e.key === "Shift") return 0xFFE1;
+  if (e.key === "Control") return 0xFFE3;
+  if (e.key === "Alt") return 0xFFE9;
+  if (e.key === "Meta") return 0xFFEB;
+  // Printable ASCII
+  if (e.key.length === 1) {
+    const code = e.key.charCodeAt(0);
+    if (code >= 0x20 && code <= 0x7E) return code;
+  }
+  return 0;
+}
+
+// --- Mouse coordinate mapping ---
+function videoCoords(e) {
+  const rect = videoEl.getBoundingClientRect();
+  const vw = videoEl.videoWidth || 1;
+  const vh = videoEl.videoHeight || 1;
+  // Compute displayed area within the element (object-fit: contain)
+  const scale = Math.min(rect.width / vw, rect.height / vh);
+  const dw = vw * scale;
+  const dh = vh * scale;
+  const ox = (rect.width - dw) / 2;
+  const oy = (rect.height - dh) / 2;
+  const lx = e.clientX - rect.left - ox;
+  const ly = e.clientY - rect.top - oy;
+  const x = Math.round((lx / dw) * vw);
+  const y = Math.round((ly / dh) * vh);
+  return [Math.max(0, Math.min(vw, x)), Math.max(0, Math.min(vh, y))];
+}
+
+function mapButton(e) {
+  // 0=left, 1=middle, 2=right
+  if (e.button === 0) return 1;
+  if (e.button === 1) return 2;
+  if (e.button === 2) return 3;
+  return 1;
+}
+
+// --- Event handlers ---
+function onMouseMove(e) {
+  if (!connected) return;
+  const [x, y] = videoCoords(e);
+  sendMouseMove(x, y);
+}
+
+function onMouseDown(e) {
+  if (!connected) return;
+  e.preventDefault();
+  imeInput.focus();
+  const [x, y] = videoCoords(e);
+  sendMouseMove(x, y);
+  sendButtonDown(mapButton(e));
+}
+
+function onMouseUp(e) {
+  if (!connected) return;
+  e.preventDefault();
+  sendButtonUp(mapButton(e));
+}
+
+function onWheel(e) {
+  if (!connected) return;
+  e.preventDefault();
+  const dx = Math.round(e.deltaX);
+  const dy = Math.round(e.deltaY);
+  sendScroll(dx, dy);
+}
+
+function onContextMenu(e) {
+  if (connected) e.preventDefault();
+}
+
+function onKeyDown(e) {
+  if (!connected) return;
+  if (e.isComposing || e.keyCode === 229) return;
+  // Don't prevent Tab if not connected
+  e.preventDefault();
+  const ks = keyToKeysym(e);
+  if (ks) sendKeyDown(ks);
+}
+
+function onKeyUp(e) {
+  if (!connected) return;
+  if (e.isComposing || e.keyCode === 229) return;
+  e.preventDefault();
+  const ks = keyToKeysym(e);
+  if (ks) sendKeyUp(ks);
+}
+
+function onCompositionStart() { isComposing = true; }
+function onCompositionEnd(e) {
+  isComposing = false;
+  if (e.data) sendInsertText(e.data);
+  imeInput.value = "";
+}
+
+// --- WebRTC ---
+async function connect() {
+  if (connected) return;
+  setStatus("Requesting offer...");
+  let offer;
+  try {
+    offer = await invoke("view.start", {});
+  } catch (err) {
+    setStatus("Failed: " + (err.message || err));
+    return;
+  }
+
+  const iceServers = (offer.ice_servers || []).map(s => ({
+    urls: s.urls || [],
+    username: s.username || undefined,
+    credential: s.credential || undefined,
+  })).filter(s => s.urls.length > 0);
+
+  const config = { iceServers: iceServers.length > 0 ? iceServers : [{ urls: "stun:stun.l.google.com:19302" }] };
+  pc = new RTCPeerConnection(config);
+
+  pc.ontrack = (e) => {
+    if (e.streams && e.streams[0]) {
+      videoEl.srcObject = e.streams[0];
+    } else {
+      const stream = new MediaStream();
+      stream.addTrack(e.track);
+      videoEl.srcObject = stream;
+    }
+    try { videoEl.playoutDelayHint = 0; } catch {}
+    try { videoEl.jitterBufferTarget = 0; } catch {}
+  };
+
+  pc.ondatachannel = (e) => {
+    dc = e.channel;
+    dc.binaryType = "arraybuffer";
+    dc.onopen = () => { setConnected(true); imeInput.focus(); };
+    dc.onclose = () => { cleanup(); };
+  };
+
+  pc.oniceconnectionstatechange = () => {
+    setStatus("ICE: " + pc.iceConnectionState);
+    if (pc.iceConnectionState === "failed" || pc.iceConnectionState === "disconnected") {
+      cleanup();
+    }
+  };
+
+  // Set remote offer
+  setStatus("Setting remote offer...");
+  try {
+    await pc.setRemoteDescription({ type: "offer", sdp: offer.offer_sdp });
+  } catch (err) {
+    setStatus("SDP error: " + err.message);
+    cleanup();
+    return;
+  }
+
+  // Add remote ICE candidates
+  const remoteCandidates = offer.candidates || [];
+  for (const c of remoteCandidates) {
+    try {
+      await pc.addIceCandidate(new RTCIceCandidate({
+        candidate: c.candidate,
+        sdpMLineIndex: c.sdpMLineIndex,
+        sdpMid: c.sdpMid || null,
+      }));
+    } catch (err) {
+      console.warn("Failed to add remote candidate:", err);
+    }
+  }
+
+  // Create answer
+  setStatus("Creating answer...");
+  const answer = await pc.createAnswer();
+  await pc.setLocalDescription(answer);
+
+  // Wait for ICE gathering complete
+  const localCandidates = [];
+  await new Promise((resolve) => {
+    if (pc.iceGatheringState === "complete") { resolve(); return; }
+    const timeout = setTimeout(resolve, 5000);
+    pc.onicegatheringstatechange = () => {
+      if (pc.iceGatheringState === "complete") { clearTimeout(timeout); resolve(); }
+    };
+    pc.onicecandidate = (e) => {
+      if (e.candidate) {
+        localCandidates.push({
+          candidate: e.candidate.candidate,
+          sdpMLineIndex: e.candidate.sdpMLineIndex,
+          sdpMid: e.candidate.sdpMid || "",
+        });
+      }
+    };
+  });
+
+  // Send answer
+  setStatus("Sending answer...");
+  try {
+    await invoke("view.answer", {
+      answer_sdp: pc.localDescription.sdp,
+      candidates: localCandidates,
+    });
+  } catch (err) {
+    setStatus("Answer failed: " + (err.message || err));
+    cleanup();
+    return;
+  }
+
+  setStatus("Waiting for connection...");
+}
+
+async function disconnect() {
+  try { await invoke("view.close", {}); } catch {}
+  cleanup();
+}
+
+function cleanup() {
+  if (dc) { try { dc.close(); } catch {} dc = null; }
+  if (pc) { try { pc.close(); } catch {} pc = null; }
+  if (videoEl.srcObject) {
+    videoEl.srcObject.getTracks().forEach(t => t.stop());
+    videoEl.srcObject = null;
+  }
+  setConnected(false);
+}
+
+// --- Event binding ---
+videoEl.addEventListener("mousemove", onMouseMove);
+videoEl.addEventListener("mousedown", onMouseDown);
+videoEl.addEventListener("mouseup", onMouseUp);
+videoEl.addEventListener("wheel", onWheel, { passive: false });
+videoEl.addEventListener("contextmenu", onContextMenu);
+
+document.addEventListener("keydown", onKeyDown);
+document.addEventListener("keyup", onKeyUp);
+
+imeInput.addEventListener("compositionstart", onCompositionStart);
+imeInput.addEventListener("compositionend", onCompositionEnd);
+
+btnConnect.addEventListener("click", () => {
+  if (connected) disconnect();
+  else connect();
+});
+
+// Focus IME input on video click
+videoEl.addEventListener("click", () => { imeInput.focus(); });
+
+// Cleanup on page unload
+window.addEventListener("beforeunload", () => {
+  if (connected) {
+    try { invoke("view.close", {}); } catch {}
+    cleanup();
+  }
+});
+</script>
+</body>
+</html>

--- a/web/view.html
+++ b/web/view.html
@@ -31,7 +31,20 @@ video { max-width: 100%; max-height: 100%; object-fit: contain; background: #000
 <textarea id="ime-input" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
 
 <script type="module">
-import { invoke } from "https://esm.sh/@pinixai/core@0.5.2/web";
+// invoke() calls the Hub's clip API endpoint. Works in subdomain mode:
+//   browser.hub.pinixai.com/api/view.start → Hub proxies to provider invoke
+async function invoke(command, input) {
+  const resp = await fetch(`/api/${command}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input || {}),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`invoke ${command} failed (${resp.status}): ${text}`);
+  }
+  return resp.json();
+}
 
 // --- State ---
 let pc = null;


### PR DESCRIPTION
Adds remote browser viewing capability: users can see and control a Chrome browser remotely through the browser clip's Web UI in Portal.

**Commits:**
1. `feat(daemon)`: expose CDP host/port in daemon.json and /status
2. `feat(provider)`: add view.start/answer/close commands + bb-viewer sidecar management
3. `feat(provider)`: add Clip Web UI for remote browser viewing
4. `feat(provider)`: TURN ephemeral credentials via TURN REST API
5. `fix(web)`: replace esm.sh import with direct /api/ fetch

**Architecture:**
- bb-viewer (Go binary) runs as a sidecar, spawned on first `view.start`
- Two invoke calls complete WebRTC signaling (non-trickle ICE)
- Video streams P2P via WebRTC, falls back to TURN relay
- Viewer page served as Clip Web UI via `GetClipWeb` — no separate deployment
- TURN credentials generated per-session using HMAC-SHA1 shared secret

**No changes to:** Hub protocol, pinix.ai API, SDK, hub-client

Closes: https://github.com/epiral/bb-viewer/issues/2