### PR TITLE
chore(ci): restore base checks

### DIFF
--- a/packages/daemon/src/cdp-connection.ts
+++ b/packages/daemon/src/cdp-connection.ts
@@ -34,29 +34,6 @@ export interface CdpTargetInfo {
 // Stealth — hide headless/automation fingerprints
 // ---------------------------------------------------------------------------
 
-const STEALTH_USER_AGENT =
-  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.7827.22 Safari/537.36";
-
-const STEALTH_UA_METADATA = {
-  brands: [
-    { brand: "Chromium", version: "149" },
-    { brand: "Google Chrome", version: "149" },
-    { brand: "Not.A/Brand", version: "24" },
-  ],
-  fullVersionList: [
-    { brand: "Chromium", version: "149.0.7827.22" },
-    { brand: "Google Chrome", version: "149.0.7827.22" },
-    { brand: "Not.A/Brand", version: "24.0.0.0" },
-  ],
-  platform: "macOS",
-  platformVersion: "10.15.7",
-  architecture: "x86",
-  bitness: "64",
-  model: "",
-  mobile: false,
-  wow64: false,
-};
-
 const STEALTH_SCRIPT = `
 (() => {
   if (window.__bbStealthApplied) return;

--- a/packages/daemon/src/chrome.ts
+++ b/packages/daemon/src/chrome.ts
@@ -178,13 +178,11 @@ async function downloadAndExtractChrome(platform: Platform): Promise<string> {
   // Try download sources in order
   const urls = getDownloadUrls(platform);
   let resp: Response | null = null;
-  let usedUrl = "";
 
   for (const url of urls) {
     console.error(`${LOG_PREFIX} Downloading Chrome ${CHROME_VERSION} (${platform}) from ${new URL(url).host}...`);
     resp = await tryFetch(url);
     if (resp) {
-      usedUrl = url;
       break;
     }
     console.error(`${LOG_PREFIX} Download failed, trying next source...`);

--- a/packages/daemon/src/command-dispatch.ts
+++ b/packages/daemon/src/command-dispatch.ts
@@ -18,9 +18,8 @@ import type {
   TraceEntry,
   TraceStatus,
 } from "@bb-browser/shared";
-import { CdpConnection, type CdpTargetInfo } from "./cdp-connection.js";
+import { CdpConnection } from "./cdp-connection.js";
 import type { TabState } from "./tab-state.js";
-import type { ActionDetail } from "./tab-state.js";
 import { getAllSites, executeSiteAdapter } from "./site-adapter.js";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove the stale `zod` dependency entry from `pnpm-lock.yaml` for `packages/shared`.
- Remove an unused `CdpTargetInfo` import that currently fails `pnpm lint` on `main`.

## Why
CI had two base-branch hygiene blockers: `pnpm install --frozen-lockfile` rejected the package/lockfile mismatch, and after that was fixed the daemon lint step failed on an unused import.

## Validation
- `CI=true pnpm install --frozen-lockfile`
- `pnpm lint`
- commit hook ran `pnpm build` and `pnpm test` successfully