### PR TITLE
feat(eval): add domain tab routing and args injection

### DIFF
--- a/packages/cli/src/commands/eval.ts
+++ b/packages/cli/src/commands/eval.ts
@@ -1,5 +1,7 @@
 /**
- * eval 命令 - 在当前页面执行 JavaScript
+ * eval 命令 - 在页面上下文中执行 JavaScript
+ *
+ * 支持 --domain 自动路由到匹配的 Tab（或新建），以及 --args 传递 JSON 参数。
  */
 
 import type { Request, Response } from "@bb-browser/shared";
@@ -9,6 +11,8 @@ import { ensureDaemonRunning } from "../daemon-manager.js";
 export interface EvalOptions {
   json?: boolean;
   tabId?: string | number;
+  domain?: string;
+  args?: string;
 }
 
 export async function evalCommand(
@@ -19,10 +23,22 @@ export async function evalCommand(
 
   await ensureDaemonRunning();
 
+  // Parse --args as JSON
+  let args: Record<string, unknown> | undefined;
+  if (options.args) {
+    try {
+      args = JSON.parse(options.args);
+    } catch {
+      throw new Error(`--args must be valid JSON: ${options.args}`);
+    }
+  }
+
   const request: Request = {
     method: "eval",
     script,
-    tabId: options.tabId,
+    ...(options.tabId !== undefined ? { tabId: options.tabId } : {}),
+    ...(options.domain ? { domain: options.domain } : {}),
+    ...(args !== undefined ? { args } : {}),
   };
 
   const response: Response = await sendCommand(request);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,11 +35,14 @@ const VERSION = __BB_BROWSER_VERSION__;
 
 // Commands that require --tab
 const TAB_REQUIRED_COMMANDS = new Set([
-  "snap", "screenshot", "get", "eval",
+  "snap", "screenshot", "get",
   "click", "hover", "fill", "type", "check", "uncheck", "select",
   "press", "scroll", "back", "forward", "reload", "close",
   "frame", "dialog", "network", "console", "errors", "trace",
 ]);
+
+// eval requires --tab unless --domain is provided
+const TAB_OR_DOMAIN_COMMANDS = new Set(["eval"]);
 
 const HELP_TEXT = `
 bb-browser - AI Agent 浏览器自动化工具
@@ -78,7 +81,7 @@ bb-browser - AI Agent 浏览器自动化工具
 页面信息：
   get text|url|title|value|html [ref]  获取页面内容 (--tab required)
   screenshot [path]            截图 (--tab required)
-  eval "<js>"                  执行 JavaScript (--tab required)
+  eval "<js>" [--domain d]     执行 JavaScript (--tab or --domain)
 
 标签页：
   tab [list|new]               管理标签页
@@ -126,6 +129,8 @@ interface ParsedArgs {
     openclaw?: boolean;
     port?: number;
     since?: string;
+    domain?: string;
+    args?: string;
   };
 }
 
@@ -197,6 +202,18 @@ function parseArgs(argv: string[]): ParsedArgs {
       skipNext = true;
     } else if (arg === "--tab") {
       skipNext = true;
+    } else if (arg === "--domain") {
+      skipNext = true;
+      const nextIdx = args.indexOf(arg) + 1;
+      if (nextIdx < args.length) {
+        result.flags.domain = args[nextIdx];
+      }
+    } else if (arg === "--args") {
+      skipNext = true;
+      const nextIdx = args.indexOf(arg) + 1;
+      if (nextIdx < args.length) {
+        result.flags.args = args[nextIdx];
+      }
     } else if (arg === "--since") {
       skipNext = true;
     } else if (arg === "--method") {
@@ -368,10 +385,19 @@ async function main(): Promise<void> {
       case "eval": {
         const script = parsed.args[0];
         if (!script) {
-          console.error("用法：bb-browser eval <script> --tab <tabId>");
+          console.error("用法：bb-browser eval <script> [--tab <tabId>] [--domain <domain>] [--args <json>]");
           process.exit(1);
         }
-        await evalCommand(script, { json: parsed.flags.json, tabId: globalTabId });
+        if (!globalTabId && !parsed.flags.domain) {
+          console.error("Missing --tab or --domain. Run 'bb-browser tab list' to see open tabs.");
+          process.exit(1);
+        }
+        await evalCommand(script, {
+          json: parsed.flags.json,
+          tabId: globalTabId,
+          domain: parsed.flags.domain,
+          args: parsed.flags.args,
+        });
         break;
       }
 

--- a/packages/daemon/src/command-dispatch.ts
+++ b/packages/daemon/src/command-dispatch.ts
@@ -505,6 +505,77 @@ let traceRecording = false;
 const traceEvents: TraceEvent[] = [];
 
 // ---------------------------------------------------------------------------
+// Domain-based tab routing
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a tab's URL hostname matches a domain (exact or subdomain).
+ */
+function matchTabDomain(tabUrl: string, domain: string): boolean {
+  try {
+    const hostname = new URL(tabUrl).hostname;
+    return hostname === domain || hostname.endsWith("." + domain);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a tab by domain: find an existing tab matching the domain, or
+ * create a new one.  Returns the targetId, shortId, and TabState.
+ */
+async function resolveTabByDomain(
+  cdp: CdpConnection,
+  domain: string,
+): Promise<{ targetId: string; shortId: string; tab: TabState }> {
+  // Search existing tabs for a hostname match
+  const targets = (await cdp.getTargets()).filter(t => t.type === "page");
+  for (const t of targets) {
+    if (matchTabDomain(t.url, domain)) {
+      await cdp.attachAndEnable(t.id);
+      const tabState = cdp.tabManager.getTab(t.id);
+      if (tabState) {
+        return { targetId: t.id, shortId: tabState.shortId, tab: tabState };
+      }
+    }
+  }
+
+  // No matching tab — create one and wait for initial load
+  const created = await cdp.browserCommand<{ targetId: string }>(
+    "Target.createTarget",
+    { url: `https://${domain}` },
+  );
+  await cdp.attachAndEnable(created.targetId);
+
+  // Wait for the page to reach a loadable state (DOMContentLoaded or timeout)
+  const LOAD_TIMEOUT = 10_000;
+  await Promise.race([
+    new Promise<void>(resolve => {
+      const check = (): void => {
+        const tab = cdp.tabManager.getTab(created.targetId);
+        // Consider loaded once the TabStateManager has tracked the new target
+        if (tab) {
+          resolve();
+          return;
+        }
+        setTimeout(check, 200);
+      };
+      // Give CDP events a tick to propagate the new target
+      setTimeout(check, 500);
+    }),
+    new Promise<void>(resolve => setTimeout(resolve, LOAD_TIMEOUT)),
+  ]);
+
+  // Additional settle time for JS-heavy pages
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
+  const tabState = cdp.tabManager.getTab(created.targetId);
+  if (!tabState) throw new Error(`Failed to create tab for domain: ${domain}`);
+
+  return { targetId: created.targetId, shortId: tabState.shortId, tab: tabState };
+}
+
+// ---------------------------------------------------------------------------
 // Main dispatch
 // ---------------------------------------------------------------------------
 
@@ -535,6 +606,27 @@ export async function dispatchRequest(
       tab: newTab?.shortId ?? created.targetId.slice(-4).toLowerCase(),
       seq: newTab?.recordAction(),
     });
+  }
+
+  // eval with domain routing: resolve tab by domain before ensurePageTarget,
+  // because there may be no existing tabs yet.
+  if (request.method === "eval" && request.domain && tabRef === undefined) {
+    if (!request.script) return fail("Missing script parameter");
+    try {
+      const resolved = await resolveTabByDomain(cdp, request.domain);
+      const seq = resolved.tab.recordAction();
+
+      let script = request.script;
+      if (request.args !== undefined) {
+        const argsJson = JSON.stringify(request.args);
+        script = `(async function(){return (${script})(${argsJson});})()`;
+      }
+
+      const result = await cdp.evaluate<unknown>(resolved.targetId, script, true);
+      return ok({ result, tab: resolved.shortId, seq });
+    } catch (error) {
+      return fail(error);
+    }
   }
 
   const target = await cdp.ensurePageTarget(
@@ -766,14 +858,21 @@ export async function dispatchRequest(
     }
 
     case "eval": {
+      // Note: eval with domain routing (no explicit tab) is handled before
+      // ensurePageTarget() above.  This branch handles eval with an explicit
+      // tab, or eval without domain.
       if (!request.script) return fail("Missing script parameter");
       const seq = tab.recordAction();
-      const result = await cdp.evaluate<unknown>(target.id, request.script, true);
-      return ok({
-        result,
-        tab: shortId,
-        seq,
-      });
+
+      // If args are provided, wrap the script in an IIFE that receives them.
+      let script = request.script;
+      if (request.args !== undefined) {
+        const argsJson = JSON.stringify(request.args);
+        script = `(async function(){return (${script})(${argsJson});})()`;
+      }
+
+      const result = await cdp.evaluate<unknown>(target.id, script, true);
+      return ok({ result, tab: shortId, seq });
     }
 
     // -----------------------------------------------------------------------

--- a/packages/shared/src/commands.ts
+++ b/packages/shared/src/commands.ts
@@ -118,10 +118,12 @@ export const COMMANDS: CommandDef[] = [
   {
     method: "eval", group: "observe",
     description: "Execute JavaScript in the page context and return the result",
-    requiresTab: true,
+    requiresTab: false,
     params: {
       script: { type: "string", required: true, position: 0, description: "JavaScript source to execute" },
-      tab: { type: "string", required: true, description: "Tab short ID" },
+      tab: { type: "string", required: false, description: "Tab short ID (optional when domain is set)" },
+      domain: { type: "string", required: false, description: "Target domain — auto-routes to a matching tab or creates one" },
+      args: { type: "string", required: false, description: "JSON arguments to pass to the script (accessible as first arg in an IIFE)" },
     },
   },
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -58,6 +58,10 @@ export interface Request {
   maxDepth?: number;
   /** JavaScript 代码（eval 命令使用） */
   script?: string;
+  /** 目标域名（eval 命令使用，自动路由到匹配的 Tab 或新建） */
+  domain?: string;
+  /** 传递给脚本的参数对象（eval 命令使用，JSON 序列化后注入脚本） */
+  args?: Record<string, unknown>;
   /** 选项值（select 命令使用） */
   value?: string;
   /** 标签页索引（tab 命令使用） */


### PR DESCRIPTION
## Summary

Enhance the `eval` command with two new parameters: `--domain` and `--args`.

### `--domain <domain>`
Auto-routes to a tab matching the domain (exact or subdomain match). If no matching tab exists, creates a new one and waits for it to load.

### `--args <json>`
Passes a JSON object to the script as function arguments. The script is wrapped in an IIFE: `(async function(){return (<script>)(<argsJSON>);})()`.

### Why

This is the foundational change for migrating site adapters to standard Bun Clips. With domain routing and args injection built into `eval`, a Bun Clip can call `browser.eval` with the same power that site adapters have today:

```typescript
// In a Bun Clip
const result = await invokeClip("browser", "eval", {
  script: loadScript("search.js"),
  domain: "x.com",
  args: { query: "AI agents" },
});
```

This enables site adapters to be published and installed via `pinix registry` like any other Clip — no special runtime needed.

### Changes

| File | Change |
|------|--------|
| `packages/shared/src/protocol.ts` | Add `domain` and `args` fields to `Request` |
| `packages/shared/src/commands.ts` | Add `domain` and `args` params to eval command def; make `tab` optional |
| `packages/daemon/src/command-dispatch.ts` | Add `resolveTabByDomain()` helper; handle eval with domain before `ensurePageTarget()` |
| `packages/cli/src/commands/eval.ts` | Add `--domain` and `--args` CLI options |
| `packages/cli/src/index.ts` | Parse `--domain`/`--args` flags; eval requires `--tab` OR `--domain` |

### Testing

Verified end-to-end:
1. CLI: `bb-browser eval "document.title" --domain news.ycombinator.com` ✅
2. CLI with args: `bb-browser eval "async function(args) { ... }" --domain news.ycombinator.com --args "{\"count\":3}"` ✅
3. Hub mode: Bun Clip (`@pinix/hackernews`) calling `invokeClip("browser", "eval", {script, domain, args})` through pinixd → bb-browser provider ✅
