### PR TITLE
feat(trace): 统一时间线——操作 + 网络请求录制，用于 site adapter 创建

### DIFF
--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -1,24 +1,44 @@
 /**
- * trace 命令 - 录制用户操作
+ * trace 命令 - 录制操作 + 网络请求的统一时间线
  */
 
-import type { Request } from "@bb-browser/shared";
+import type { Request, TraceEntry } from "@bb-browser/shared";
 import { sendCommand } from "../client.js";
 
 interface TraceOptions {
   json?: boolean;
   tabId?: string | number;
+  since?: number | string;
+  type?: string;
+  filter?: string;
+  limit?: number;
+  requestId?: string;
 }
 
 export async function traceCommand(
-  subCommand: 'start' | 'stop' | 'status',
+  subCommand: 'start' | 'stop' | 'status' | 'events' | 'body',
   options: TraceOptions = {}
 ): Promise<void> {
-  const response = await sendCommand({
+  const request: Record<string, unknown> = {
     method: "trace",
     traceCommand: subCommand,
     tabId: options.tabId,
-  } as Request);
+  };
+
+  // events-specific params
+  if (subCommand === 'events') {
+    if (options.since !== undefined) request.since = Number(options.since);
+    if (options.type) request.traceType = options.type;
+    if (options.filter) request.filter = options.filter;
+    if (options.limit) request.limit = Number(options.limit);
+  }
+
+  // body-specific params
+  if (subCommand === 'body') {
+    request.requestId = options.requestId;
+  }
+
+  const response = await sendCommand(request as Request);
 
   if (options.json) {
     console.log(JSON.stringify(response));
@@ -34,70 +54,95 @@ export async function traceCommand(
   switch (subCommand) {
     case "start": {
       const status = data?.traceStatus;
-      console.log("开始录制用户操作");
-      console.log(`标签页 ID: ${status?.tabId || 'N/A'}`);
-      console.log("\n在浏览器中进行操作，完成后运行 'bb-browser trace stop' 停止录制");
+      console.log("Trace started");
+      if (status?.tracedTabs?.length) {
+        console.log(`Tracing tabs: ${status.tracedTabs.join(', ')}`);
+      }
+      console.log("\nOperate the browser, then run 'bb-browser trace events' to see the timeline.");
       break;
     }
 
     case "stop": {
-      const events = data?.traceEvents || [];
-      
-      console.log(`录制完成，共 ${events.length} 个事件\n`);
-      
-      if (events.length === 0) {
-        console.log("没有录制到任何操作");
-        break;
-      }
-      
-      for (let i = 0; i < events.length; i++) {
-        const event = events[i];
-        const refStr = event.ref !== undefined ? `@${event.ref}` : '';
-        
-        switch (event.type) {
-          case 'navigation':
-            console.log(`${i + 1}. 导航到: ${event.url}`);
-            break;
-          case 'click':
-            console.log(`${i + 1}. 点击 ${refStr} [${event.elementRole}] "${event.elementName || ''}"`);
-            break;
-          case 'fill':
-            console.log(`${i + 1}. 填充 ${refStr} [${event.elementRole}] "${event.elementName || ''}" <- "${event.value}"`);
-            break;
-          case 'select':
-            console.log(`${i + 1}. 选择 ${refStr} [${event.elementRole}] "${event.elementName || ''}" <- "${event.value}"`);
-            break;
-          case 'check':
-            console.log(`${i + 1}. ${event.checked ? '勾选' : '取消勾选'} ${refStr} [${event.elementRole}] "${event.elementName || ''}"`);
-            break;
-          case 'press':
-            console.log(`${i + 1}. 按键 ${event.key}`);
-            break;
-          case 'scroll':
-            console.log(`${i + 1}. 滚动 ${event.direction} ${event.pixels}px`);
-            break;
-          default:
-            console.log(`${i + 1}. ${event.type}`);
-        }
-      }
-      
       const status = data?.traceStatus;
-      console.log(`\n状态: ${status?.recording ? '录制中' : '已停止'}`);
+      console.log(`Trace stopped (${status?.eventCount ?? 0} events recorded)`);
+      console.log("Data preserved — use 'trace events' to query, 'trace start' to begin a new session.");
       break;
     }
 
     case "status": {
       const status = data?.traceStatus;
       if (status?.recording) {
-        console.log(`录制中 (标签页 ${status.tabId})`);
-        console.log(`已录制 ${status.eventCount} 个事件`);
+        console.log(`Recording (${status.eventCount} events)`);
+        if (status.tracedTabs?.length) {
+          console.log(`Tabs: ${status.tracedTabs.join(', ')}`);
+        }
+      } else if (status?.eventCount) {
+        console.log(`Stopped (${status.eventCount} events in buffer)`);
       } else {
-        console.log("未在录制");
+        console.log("No active trace session");
       }
       break;
     }
 
-    default:
-      throw new Error(`未知的 trace 子命令: ${subCommand}`);
+    case "events": {
+      const events = (data?.traceEvents || []) as TraceEntry[];
+      const cursor = (data as Record<string, unknown>)?.cursor;
+
+      if (events.length === 0) {
+        console.log("No events");
+        break;
+      }
+
+      // Print timeline
+      for (const e of events) {
+        const tabStr = `[${e.tab}]`;
+        switch (e.type) {
+          case 'action': {
+            const src = e.source === 'human' ? ' (human)' : '';
+            const ref = e.ref !== undefined ? ` ref=${e.ref}` : '';
+            const val = e.value ? ` "${e.value}"` : '';
+            const key = e.key ? ` ${e.key}` : '';
+            const info = e.text ? ` "${e.text}"` : '';
+            const role = e.role ? ` [${e.role}]` : '';
+            console.log(`  ${e.seq}  ${tabStr}  action${src}    ${e.action}${ref}${role}${info}${val}${key}`);
+            break;
+          }
+          case 'request': {
+            const trigger = e.triggerSeq ? `  trigger:${e.triggerSeq}` : '';
+            const body = e.body ? ` (body: ${e.body.length}B)` : '';
+            console.log(`  ${e.seq}  ${tabStr}  request      ${e.method} ${e.url}${body}${trigger}`);
+            break;
+          }
+          case 'response': {
+            const size = e.bodySize ? ` ${e.bodySize}B` : '';
+            const mime = e.mimeType ? ` ${e.mimeType}` : '';
+            console.log(`  ${e.seq}  ${tabStr}  response     ${e.requestId} → ${e.status}${mime}${size}`);
+            break;
+          }
+          case 'navigation': {
+            const from = e.from ? ` (from: ${e.from})` : '';
+            console.log(`  ${e.seq}  ${tabStr}  navigation   ${e.url}${from}`);
+            break;
+          }
+        }
+      }
+
+      console.log(`\n${events.length} events, cursor: ${cursor}`);
+      break;
+    }
+
+    case "body": {
+      const body = data?.traceBody;
+      if (!body) {
+        console.error("No body data returned");
+        break;
+      }
+      if (body.base64Encoded) {
+        console.log(`[base64 encoded, ${body.body.length} chars]`);
+      } else {
+        console.log(body.body);
+      }
+      break;
+    }
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -95,7 +95,11 @@ bb-browser - AI Agent 浏览器自动化工具
   network requests [filter]    查看网络请求 (--tab required)
   console [--clear]            查看/清空控制台 (--tab required)
   errors [--clear]             查看/清空 JS 错误 (--tab required)
-  trace start|stop|status      录制用户操作 (--tab required)
+  trace start [--tab <id>]     录制操作+网络的统一时间线
+  trace events [--type action|request] 查看时间线（支持 --since/--filter/--tab）
+  trace body <requestId>       获取某个请求的 response body
+  trace stop                   停止录制（数据保留）
+  trace status                 查看录制状态
   daemon [start|status|stop]   管理 daemon
 
 选项：
@@ -108,6 +112,11 @@ bb-browser - AI Agent 浏览器自动化工具
   -d, --depth <n>      限制树深度（snap 命令）
   -s, --selector <sel> 限定 CSS 选择器范围（snap 命令）
   --tab <tabId>        指定操作的标签页 ID
+  --since <seq>        增量查询（network/console/errors/trace events）
+  --type <t>           过滤事件类型（trace events: action/request/response）
+  --filter <str>       URL 或文字过滤（trace events/network requests）
+  --limit <n>          限制返回条数
+  --request-id <id>    请求 ID（trace body）
   --help, -h           显示帮助信息
   --version, -v        显示版本号
 `.trim();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -38,7 +38,7 @@ const TAB_REQUIRED_COMMANDS = new Set([
   "snap", "screenshot", "get",
   "click", "hover", "fill", "type", "check", "uncheck", "select",
   "press", "scroll", "back", "forward", "reload", "close",
-  "frame", "dialog", "network", "console", "errors", "trace",
+  "frame", "dialog", "network", "console", "errors",
 ]);
 
 // eval requires --tab unless --domain is provided
@@ -220,6 +220,30 @@ function parseArgs(argv: string[]): ParsedArgs {
       skipNext = true;
     } else if (arg === "--status") {
       skipNext = true;
+    } else if (arg === "--type") {
+      skipNext = true;
+      const nextIdx = args.indexOf(arg) + 1;
+      if (nextIdx < args.length) {
+        (result.flags as Record<string, unknown>).type = args[nextIdx];
+      }
+    } else if (arg === "--filter") {
+      skipNext = true;
+      const nextIdx = args.indexOf(arg) + 1;
+      if (nextIdx < args.length) {
+        (result.flags as Record<string, unknown>).filter = args[nextIdx];
+      }
+    } else if (arg === "--limit") {
+      skipNext = true;
+      const nextIdx = args.indexOf(arg) + 1;
+      if (nextIdx < args.length) {
+        (result.flags as Record<string, unknown>).limit = parseInt(args[nextIdx], 10);
+      }
+    } else if (arg === "--request-id") {
+      skipNext = true;
+      const nextIdx = args.indexOf(arg) + 1;
+      if (nextIdx < args.length) {
+        (result.flags as Record<string, unknown>)["request-id"] = args[nextIdx];
+      }
     } else if (arg.startsWith("-")) {
       // Unknown flags, ignore
     } else if (result.command === null) {
@@ -559,12 +583,21 @@ async function main(): Promise<void> {
       }
 
       case "trace": {
-        const subCmd = parsed.args[0] as 'start' | 'stop' | 'status' | undefined;
-        if (!subCmd || !['start', 'stop', 'status'].includes(subCmd)) {
-          console.error("用法：bb-browser trace <start|stop|status> --tab <tabId>");
+        const subCmd = parsed.args[0] as 'start' | 'stop' | 'status' | 'events' | 'body' | undefined;
+        if (!subCmd || !['start', 'stop', 'status', 'events', 'body'].includes(subCmd)) {
+          console.error("用法：bb-browser trace <start|stop|status|events|body> [--tab <tabId>]");
           process.exit(1);
         }
-        await traceCommand(subCmd, { json: parsed.flags.json, tabId: globalTabId });
+        const f = parsed.flags as Record<string, unknown>;
+        await traceCommand(subCmd, {
+          json: parsed.flags.json,
+          tabId: globalTabId,
+          since: globalSince,
+          type: f.type as string | undefined,
+          filter: f.filter as string | undefined,
+          limit: f.limit as number | undefined,
+          requestId: (f["request-id"] as string | undefined) || parsed.args[1],
+        });
         break;
       }
 

--- a/packages/daemon/src/cdp-connection.ts
+++ b/packages/daemon/src/cdp-connection.ts
@@ -470,7 +470,19 @@ export class CdpConnection {
         const params = message.params as JsonObject;
         const targetInfo = params.targetInfo as JsonObject;
         if (targetInfo?.type === "page" && typeof targetInfo.targetId === "string") {
-          this.attachAndEnable(targetInfo.targetId).catch(() => {});
+          const newTargetId = targetInfo.targetId;
+          const openerId = typeof targetInfo.openerId === "string" ? targetInfo.openerId : undefined;
+          this.attachAndEnable(newTargetId).catch(() => {});
+
+          // Auto-join trace session if opener is being traced
+          const session = this.tabManager.traceSession;
+          if (session?.active && openerId && session.tracedTabs.has(openerId)) {
+            session.tracedTabs.add(newTargetId);
+            // Enable human capture on the new tab (delay to let attach complete)
+            setTimeout(() => {
+              this.enableHumanCapture(newTargetId).catch(() => {});
+            }, 500);
+          }
         }
         return;
       }
@@ -550,14 +562,36 @@ export class CdpConnection {
       const requestId = typeof params.requestId === "string" ? params.requestId : undefined;
       const request = params.request as JsonObject | undefined;
       if (!requestId || !request) return;
+      const url = String(request.url ?? "");
+      const reqMethod = String(request.method ?? "GET");
+      const resourceType = String(params.type ?? "Other");
+      const headers = normalizeHeaders(request.headers);
+      const body = typeof request.postData === "string" ? request.postData : undefined;
       tab.addNetworkRequest(requestId, {
-        url: String(request.url ?? ""),
-        method: String(request.method ?? "GET"),
-        type: String(params.type ?? "Other"),
+        url,
+        method: reqMethod,
+        type: resourceType,
         timestamp: Math.round(Number(params.timestamp ?? Date.now()) * 1000),
-        requestHeaders: normalizeHeaders(request.headers),
-        requestBody: typeof request.postData === "string" ? request.postData : undefined,
+        requestHeaders: headers,
+        requestBody: body,
       });
+      // Push to trace timeline
+      if (this.tabManager.isTraced(targetId)) {
+        const now = Date.now();
+        this.tabManager.tracePush({
+          seq: this.tabManager.nextSeq(),
+          ts: now,
+          tab: tab.shortId,
+          type: 'request',
+          requestId,
+          method: reqMethod,
+          url,
+          resourceType,
+          headers,
+          body,
+          triggerSeq: this.tabManager.inferTriggerSeq(now),
+        });
+      }
       return;
     }
 
@@ -565,12 +599,26 @@ export class CdpConnection {
       const requestId = typeof params.requestId === "string" ? params.requestId : undefined;
       const response = params.response as JsonObject | undefined;
       if (!requestId || !response) return;
+      const status = typeof response.status === "number" ? response.status : 0;
+      const mimeType = typeof response.mimeType === "string" ? response.mimeType : undefined;
       tab.updateNetworkResponse(requestId, {
         status: typeof response.status === "number" ? response.status : undefined,
         statusText: typeof response.statusText === "string" ? response.statusText : undefined,
         responseHeaders: normalizeHeaders(response.headers),
-        mimeType: typeof response.mimeType === "string" ? response.mimeType : undefined,
+        mimeType,
       });
+      // Push to trace timeline
+      if (this.tabManager.isTraced(targetId)) {
+        this.tabManager.tracePush({
+          seq: this.tabManager.nextSeq(),
+          ts: Date.now(),
+          tab: tab.shortId,
+          type: 'response',
+          requestId,
+          status,
+          mimeType,
+        });
+      }
       return;
     }
 
@@ -655,6 +703,31 @@ export class CdpConnection {
             : undefined,
         timestamp: Date.now(),
       });
+    }
+
+    // Human action capture via Runtime.bindingCalled
+    if (method === "Runtime.bindingCalled") {
+      const name = params.name;
+      const payload = params.payload;
+      if (name === "__bb_trace" && typeof payload === "string" && this.tabManager.isTraced(targetId)) {
+        try {
+          const data = JSON.parse(payload) as Record<string, unknown>;
+          this.tabManager.tracePush({
+            seq: this.tabManager.nextSeq(),
+            ts: Date.now(),
+            tab: tab.shortId,
+            type: 'action',
+            source: 'human',
+            action: String(data.action ?? 'unknown'),
+            selector: typeof data.selector === 'string' ? data.selector : undefined,
+            text: typeof data.text === 'string' ? data.text : undefined,
+            role: typeof data.role === 'string' ? data.role : undefined,
+            tag: typeof data.tag === 'string' ? data.tag : undefined,
+            value: typeof data.value === 'string' ? data.value : undefined,
+            key: typeof data.key === 'string' ? data.key : undefined,
+          });
+        } catch {}
+      }
     }
   }
 
@@ -753,6 +826,57 @@ export class CdpConnection {
     }
 
     return result.sessionId;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Human action capture for trace
+  // ---------------------------------------------------------------------------
+
+  private static readonly HUMAN_CAPTURE_SCRIPT = `(function() {
+    if (window.__bb_trace_installed) return;
+    window.__bb_trace_installed = true;
+    function report(data) {
+      try { window.__bb_trace(JSON.stringify(data)); } catch(e) {}
+    }
+    function meta(el) {
+      if (!el || !el.tagName) return {};
+      return {
+        tag: el.tagName,
+        text: (el.innerText || '').slice(0, 80).trim(),
+        role: el.getAttribute ? el.getAttribute('role') : undefined,
+        selector: el.id ? '#' + el.id
+          : el.className && typeof el.className === 'string' ? el.tagName.toLowerCase() + '.' + el.className.split(' ')[0]
+          : el.tagName.toLowerCase(),
+      };
+    }
+    document.addEventListener('click', function(e) {
+      report({ action: 'click', ...meta(e.target), x: e.clientX, y: e.clientY });
+    }, true);
+    document.addEventListener('input', function(e) {
+      report({ action: 'input', ...meta(e.target), value: e.target.value });
+    }, true);
+    document.addEventListener('keydown', function(e) {
+      if (['Enter','Tab','Escape','Backspace','Delete'].indexOf(e.key) >= 0 || e.ctrlKey || e.metaKey) {
+        report({ action: 'press', key: e.key, ...meta(e.target) });
+      }
+    }, true);
+    document.addEventListener('submit', function(e) {
+      report({ action: 'submit', ...meta(e.target) });
+    }, true);
+  })();`;
+
+  /** Inject human action capture listeners into a tab via CDP binding. */
+  async enableHumanCapture(targetId: string): Promise<void> {
+    try {
+      await this.sessionCommand(targetId, "Runtime.addBinding", { name: "__bb_trace" });
+    } catch {
+      // Binding may already exist
+    }
+    await this.sessionCommand(targetId, "Page.addScriptToEvaluateOnNewDocument", {
+      source: CdpConnection.HUMAN_CAPTURE_SCRIPT,
+    }).catch(() => {});
+    // Also evaluate immediately for the current page
+    await this.evaluate(targetId, CdpConnection.HUMAN_CAPTURE_SCRIPT, false).catch(() => {});
   }
 
   /** Get all targets via CDP Target.getTargets. */

--- a/packages/daemon/src/cdp-connection.ts
+++ b/packages/daemon/src/cdp-connection.ts
@@ -442,8 +442,29 @@ export class CdpConnection {
         const sessionId = params.sessionId;
         const targetInfo = params.targetInfo as JsonObject;
         if (typeof sessionId === "string" && typeof targetInfo?.targetId === "string") {
-          this.sessions.set(targetInfo.targetId, sessionId);
-          this.attachedTargets.set(sessionId, targetInfo.targetId);
+          const targetId = targetInfo.targetId;
+          this.sessions.set(targetId, sessionId);
+          this.attachedTargets.set(sessionId, targetId);
+
+          // Re-enable CDP domains on the new session. This handles same-tab
+          // navigation where Chrome detaches the old session and creates a new
+          // one — CDP domains (Network, Runtime, etc.) must be re-enabled.
+          const existingTab = this.tabManager.getTab(targetId);
+          if (existingTab) {
+            this.sessionCommand(targetId, "Page.enable").catch(() => {});
+            this.sessionCommand(targetId, "Runtime.enable").catch(() => {});
+            this.sessionCommand(targetId, "Network.enable").catch(() => {});
+            this.sessionCommand(targetId, "DOM.enable").catch(() => {});
+            this.sessionCommand(targetId, "Accessibility.enable").catch(() => {});
+
+            // Re-inject human capture if this tab is being traced
+            if (this.tabManager.isTraced(targetId)) {
+              this.enableHumanCapture(targetId).catch(() => {});
+            }
+          } else {
+            // New target — register tab state
+            this.tabManager.addTab(targetId);
+          }
         }
         return;
       }
@@ -456,10 +477,11 @@ export class CdpConnection {
           if (targetId) {
             this.sessions.delete(targetId);
             this.attachedTargets.delete(sessionId);
-            this.tabManager.removeTab(targetId);
-            if (this.currentTargetId === targetId) {
-              this.currentTargetId = undefined;
-            }
+            // Do NOT call tabManager.removeTab() here — detach can happen
+            // during same-tab navigation (cross-origin). The tab target still
+            // exists; only Target.targetDestroyed should remove tab state.
+            // Session maps are cleaned so the old sessionId won't route events,
+            // but the tab's event buffers (network, console, etc.) are preserved.
           }
         }
         return;

--- a/packages/daemon/src/command-dispatch.ts
+++ b/packages/daemon/src/command-dispatch.ts
@@ -15,11 +15,12 @@ import type {
   ResponseData,
   RefInfo,
   SnapshotData,
-  TraceEvent,
+  TraceEntry,
   TraceStatus,
 } from "@bb-browser/shared";
 import { CdpConnection, type CdpTargetInfo } from "./cdp-connection.js";
 import type { TabState } from "./tab-state.js";
+import type { ActionDetail } from "./tab-state.js";
 import { getAllSites, executeSiteAdapter } from "./site-adapter.js";
 
 // ---------------------------------------------------------------------------
@@ -497,12 +498,7 @@ async function getAttributeValue(
   return String(call.result.value ?? "");
 }
 
-// ---------------------------------------------------------------------------
-// Trace state (global, not per-tab — matches original behavior)
-// ---------------------------------------------------------------------------
-
-let traceRecording = false;
-const traceEvents: TraceEvent[] = [];
+// Trace state is now managed by TabStateManager.traceSession
 
 // ---------------------------------------------------------------------------
 // Domain-based tab routing
@@ -604,7 +600,7 @@ export async function dispatchRequest(
       tabId: created.targetId,
       url,
       tab: newTab?.shortId ?? created.targetId.slice(-4).toLowerCase(),
-      seq: newTab?.recordAction(),
+      seq: newTab?.recordAction({ action: 'tab_new', url: url }),
     });
   }
 
@@ -614,7 +610,7 @@ export async function dispatchRequest(
     if (!request.script) return fail("Missing script parameter");
     try {
       const resolved = await resolveTabByDomain(cdp, request.domain);
-      const seq = resolved.tab.recordAction();
+      const seq = resolved.tab.recordAction({ action: 'eval', url: request.domain });
 
       let script = request.script;
       if (request.args !== undefined) {
@@ -643,7 +639,7 @@ export async function dispatchRequest(
     // -----------------------------------------------------------------------
     case "open": {
       if (!request.url) return fail("Missing url parameter");
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: 'open', url: request.url });
       if (tabRef === undefined) {
         // No specific tab requested — open in new tab
         const created = await cdp.browserCommand<{ targetId: string }>(
@@ -671,25 +667,25 @@ export async function dispatchRequest(
     }
 
     case "back": {
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: 'back' });
       await cdp.evaluate(target.id, "history.back(); undefined");
       return ok({ tab: shortId, seq });
     }
 
     case "forward": {
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: 'forward' });
       await cdp.evaluate(target.id, "history.forward(); undefined");
       return ok({ tab: shortId, seq });
     }
 
     case "reload": {
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: 'reload' });
       await cdp.sessionCommand(target.id, "Page.reload", { ignoreCache: false });
       return ok({ tab: shortId, seq });
     }
 
     case "close": {
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: 'close' });
       await cdp.browserCommand("Target.closeTarget", { targetId: target.id });
       tab.refs = {};
       return ok({ tab: shortId, seq });
@@ -735,7 +731,14 @@ export async function dispatchRequest(
     case "click":
     case "hover": {
       if (!request.ref) return fail("Missing ref parameter");
-      const seq = tab.recordAction();
+      const refInfo = tab.refs[request.ref];
+      const seq = tab.recordAction({
+        action: request.method,
+        ref: Number(request.ref),
+        text: refInfo?.name?.slice(0, 80),
+        role: refInfo?.role,
+        tag: refInfo?.tagName,
+      });
       const backendNodeId = await parseRef(cdp, target.id, tab, request.ref);
       const point = await getInteractablePoint(cdp, target.id, backendNodeId);
       await cdp.sessionCommand(target.id, "Input.dispatchMouseEvent", {
@@ -751,7 +754,15 @@ export async function dispatchRequest(
     case "type": {
       if (!request.ref) return fail("Missing ref parameter");
       if (request.text == null) return fail("Missing text parameter");
-      const seq = tab.recordAction();
+      const fillRefInfo = tab.refs[request.ref];
+      const seq = tab.recordAction({
+        action: request.method,
+        ref: Number(request.ref),
+        value: request.text,
+        text: fillRefInfo?.name?.slice(0, 80),
+        role: fillRefInfo?.role,
+        tag: fillRefInfo?.tagName,
+      });
       const backendNodeId = await parseRef(cdp, target.id, tab, request.ref);
       await insertTextIntoNode(cdp, target.id, backendNodeId, request.text, request.method === "fill");
       return ok({
@@ -764,7 +775,7 @@ export async function dispatchRequest(
     case "check":
     case "uncheck": {
       if (!request.ref) return fail("Missing ref parameter");
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: request.method, ref: Number(request.ref) });
       const desired = request.method === "check";
       const backendNodeId = await parseRef(cdp, target.id, tab, request.ref);
       const resolved = await cdp.sessionCommand<{ object: { objectId: string } }>(
@@ -781,7 +792,7 @@ export async function dispatchRequest(
 
     case "select": {
       if (!request.ref || request.value == null) return fail("Missing ref or value parameter");
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: 'select', ref: Number(request.ref), value: request.value });
       const backendNodeId = await parseRef(cdp, target.id, tab, request.ref);
       const resolved = await cdp.sessionCommand<{ object: { objectId: string } }>(
         target.id,
@@ -825,7 +836,7 @@ export async function dispatchRequest(
 
     case "press": {
       if (!request.key) return fail("Missing key parameter");
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: 'press', key: request.key });
       await cdp.sessionCommand(target.id, "Input.dispatchKeyEvent", {
         type: "keyDown", key: request.key,
       });
@@ -841,7 +852,7 @@ export async function dispatchRequest(
     }
 
     case "scroll": {
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: 'scroll', direction: request.direction });
       const pixels = request.pixels ?? 300;
       let deltaX = 0;
       let deltaY = 0;
@@ -862,7 +873,7 @@ export async function dispatchRequest(
       // ensurePageTarget() above.  This branch handles eval with an explicit
       // tab, or eval without domain.
       if (!request.script) return fail("Missing script parameter");
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: 'eval' });
 
       // If args are provided, wrap the script in an IIFE that receives them.
       let script = request.script;
@@ -904,7 +915,7 @@ export async function dispatchRequest(
     // -----------------------------------------------------------------------
     case "frame": {
       if (!request.selector) return fail("Missing selector parameter");
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: 'frame' });
       const document = await cdp.pageCommand<{ root: { nodeId: number } }>(
         target.id,
         "DOM.getDocument",
@@ -944,7 +955,7 @@ export async function dispatchRequest(
     }
 
     case "frame_main": {
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: 'frame_main' });
       tab.activeFrameId = null;
       return ok({
         frameInfo: { frameId: 0 },
@@ -957,7 +968,7 @@ export async function dispatchRequest(
     // Dialog
     // -----------------------------------------------------------------------
     case "dialog": {
-      const seq = tab.recordAction();
+      const seq = tab.recordAction({ action: 'dialog' });
       tab.dialogHandler = {
         accept: request.dialogResponse !== "dismiss",
         ...(request.promptText !== undefined ? { promptText: request.promptText } : {}),
@@ -1085,27 +1096,122 @@ export async function dispatchRequest(
     // -----------------------------------------------------------------------
     case "trace": {
       const subCommand = request.traceCommand ?? "status";
+      const tm = cdp.tabManager;
       switch (subCommand) {
-        case "start":
-          traceRecording = true;
-          traceEvents.length = 0;
+        case "start": {
+          // Resolve target tab if specified
+          let traceTargetId: string | undefined;
+          if (tabRef !== undefined) {
+            traceTargetId = target.id;
+          }
+          const session = tm.traceStart(traceTargetId);
+          // Enable human action capture on traced tabs
+          for (const tid of session.tracedTabs) {
+            cdp.enableHumanCapture(tid).catch(() => {});
+          }
+          const tracedShortIds = Array.from(session.tracedTabs)
+            .map(tid => tm.getTabShortId(tid))
+            .filter(Boolean) as string[];
           return ok({
-            traceStatus: { recording: true, eventCount: 0 } satisfies TraceStatus,
-            tab: shortId,
-          });
-        case "stop": {
-          traceRecording = false;
-          return ok({
-            traceEvents: [...traceEvents],
-            traceStatus: { recording: false, eventCount: traceEvents.length } satisfies TraceStatus,
+            traceStatus: { recording: true, eventCount: 0, tracedTabs: tracedShortIds } satisfies TraceStatus,
             tab: shortId,
           });
         }
-        case "status":
+        case "stop": {
+          const session = tm.traceSession;
+          tm.traceStop();
           return ok({
-            traceStatus: { recording: traceRecording, eventCount: traceEvents.length } satisfies TraceStatus,
+            traceStatus: {
+              recording: false,
+              eventCount: session?.timeline.length ?? 0,
+              tracedTabs: session ? Array.from(session.tracedTabs).map(tid => tm.getTabShortId(tid)).filter(Boolean) as string[] : [],
+            } satisfies TraceStatus,
             tab: shortId,
           });
+        }
+        case "status": {
+          const session = tm.traceSession;
+          return ok({
+            traceStatus: {
+              recording: session?.active ?? false,
+              eventCount: session?.timeline.length ?? 0,
+              tracedTabs: session ? Array.from(session.tracedTabs).map(tid => tm.getTabShortId(tid)).filter(Boolean) as string[] : [],
+            } satisfies TraceStatus,
+            tab: shortId,
+          });
+        }
+        case "events": {
+          const session = tm.traceSession;
+          if (!session) return ok({ traceEvents: [], cursor: 0, tab: shortId });
+
+          let events: TraceEntry[] = [...session.timeline];
+
+          // Filter by tab
+          if (request.tabId !== undefined) {
+            const filterTab = String(request.tabId);
+            events = events.filter(e => e.tab === filterTab);
+          }
+
+          // Filter by type
+          if (request.traceType) {
+            events = events.filter(e => e.type === request.traceType);
+          }
+
+          // Incremental query (since)
+          if (request.since !== undefined) {
+            const threshold = typeof request.since === 'number' ? request.since : 0;
+            events = events.filter(e => e.seq > threshold);
+          }
+
+          // Text/URL filter
+          if (request.filter) {
+            const f = request.filter.toLowerCase();
+            events = events.filter(e => {
+              if (e.type === 'request') return e.url.toLowerCase().includes(f);
+              if (e.type === 'navigation') return e.url.toLowerCase().includes(f);
+              if (e.type === 'action') return (e.text || e.action || '').toLowerCase().includes(f);
+              return false;
+            });
+          }
+
+          // Limit
+          if (request.limit !== undefined && request.limit > 0 && events.length > request.limit) {
+            events = events.slice(-request.limit);
+          }
+
+          const cursor = events.length > 0 ? events[events.length - 1].seq : (typeof request.since === 'number' ? request.since : 0);
+          return ok({ traceEvents: events, cursor, tab: shortId });
+        }
+        case "body": {
+          if (!request.requestId) return fail("Missing requestId parameter");
+          const session = tm.traceSession;
+          if (!session) return fail("No trace session");
+
+          // Find the request entry to get its tab
+          const reqEntry = session.timeline.find(
+            e => e.type === 'request' && e.requestId === request.requestId,
+          );
+          if (!reqEntry || reqEntry.type !== 'request') return fail(`Request ${request.requestId} not found in trace`);
+
+          // Resolve the tab's targetId to fetch the body
+          const reqTabShortId = reqEntry.tab;
+          const reqTargetId = tm.resolveShortId(reqTabShortId);
+          if (!reqTargetId) return fail(`Tab ${reqTabShortId} no longer exists`);
+
+          try {
+            const body = await cdp.sessionCommand<{ body: string; base64Encoded: boolean }>(
+              reqTargetId,
+              "Network.getResponseBody",
+              { requestId: request.requestId },
+            );
+            return ok({
+              traceBody: { requestId: request.requestId, body: body.body, base64Encoded: body.base64Encoded },
+              tab: shortId,
+            });
+          } catch (error) {
+            return fail(error);
+          }
+        }
         default:
           return fail(`Unknown trace subcommand: ${subCommand}`);
       }

--- a/packages/daemon/src/tab-state.ts
+++ b/packages/daemon/src/tab-state.ts
@@ -16,8 +16,35 @@ import type {
   ConsoleMessageInfo,
   JSErrorInfo,
   RefInfo,
+  TraceEntry,
+  TraceAction,
 } from "@bb-browser/shared";
 import { RingBuffer } from "./ring-buffer.js";
+
+// ---------------------------------------------------------------------------
+// Trace session — lives on TabStateManager, spans multiple tabs
+// ---------------------------------------------------------------------------
+
+export interface TraceSession {
+  /** Whether recording is active */
+  active: boolean;
+  /** Set of targetIds being traced */
+  tracedTabs: Set<string>;
+  /** Unified timeline of all events across traced tabs */
+  timeline: TraceEntry[];
+  /** Seq at the start of recording */
+  startSeq: number;
+}
+
+/** Detail passed to recordAction when trace is active */
+export interface ActionDetail {
+  action: string;
+  ref?: number;
+  value?: string;
+  key?: string;
+  direction?: string;
+  url?: string;
+}
 
 // ---------------------------------------------------------------------------
 // Seq-tagged event wrappers
@@ -58,6 +85,9 @@ export class TabState {
   /** Dialog auto-handler config. */
   dialogHandler: { accept: boolean; promptText?: string } | null = null;
 
+  /** Reference to the manager (set after construction) */
+  manager!: TabStateManager;
+
   constructor(
     targetId: string,
     shortId: string,
@@ -69,10 +99,31 @@ export class TabState {
 
   // --------------- Action seq ---------------
 
-  /** Increment global seq and record it as this tab's last action. */
-  recordAction(): number {
+  /** Increment global seq and record it as this tab's last action.
+   *  When trace is active, pushes a TraceAction to the timeline. */
+  recordAction(detail?: ActionDetail): number {
     const seq = this.nextSeq();
     this.lastActionSeq = seq;
+
+    // Push to trace timeline if this tab is being traced
+    const session = this.manager?.traceSession;
+    if (session?.active && session.tracedTabs.has(this.targetId) && detail) {
+      const entry: TraceAction = {
+        seq,
+        ts: Date.now(),
+        tab: this.shortId,
+        type: 'action',
+        source: 'command',
+        action: detail.action,
+        ref: detail.ref,
+        value: detail.value,
+        key: detail.key,
+        direction: detail.direction,
+        url: detail.url,
+      };
+      session.timeline.push(entry);
+    }
+
     return seq;
   }
 
@@ -266,6 +317,9 @@ export class TabStateManager {
   private shortToTarget = new Map<string, string>(); // shortId -> targetId
   private targetToShort = new Map<string, string>(); // targetId -> shortId
 
+  /** Active trace session (at most one at a time) */
+  traceSession: TraceSession | null = null;
+
   /** Generate a globally unique short ID for a target. */
   private generateShortId(targetId: string): string {
     for (let len = 4; len <= targetId.length; len++) {
@@ -295,6 +349,7 @@ export class TabStateManager {
 
     const shortId = this.generateShortId(targetId);
     const tab = new TabState(targetId, shortId, () => this.nextSeq());
+    tab.manager = this;
     this.tabs.set(targetId, tab);
     this.shortToTarget.set(shortId, targetId);
     this.targetToShort.set(targetId, shortId);
@@ -333,5 +388,61 @@ export class TabStateManager {
   /** Get tab count. */
   get tabCount(): number {
     return this.tabs.size;
+  }
+
+  // --------------- Trace session helpers ---------------
+
+  /** Start a new trace session. If a targetId is given, only trace that tab
+   *  (plus any tabs it opens). If omitted, trace all current and future tabs. */
+  traceStart(targetId?: string): TraceSession {
+    const tracedTabs = new Set<string>();
+    if (targetId) {
+      tracedTabs.add(targetId);
+    } else {
+      for (const tid of this.tabs.keys()) tracedTabs.add(tid);
+    }
+    this.traceSession = {
+      active: true,
+      tracedTabs,
+      timeline: [],
+      startSeq: this.seq,
+    };
+    return this.traceSession;
+  }
+
+  /** Stop the current trace session. Data is preserved for querying. */
+  traceStop(): void {
+    if (this.traceSession) {
+      this.traceSession.active = false;
+    }
+  }
+
+  /** Push a trace entry (used by cdp-connection for network/navigation events). */
+  tracePush(entry: TraceEntry): void {
+    this.traceSession?.timeline.push(entry);
+  }
+
+  /** Check if a target is being traced. */
+  isTraced(targetId: string): boolean {
+    const s = this.traceSession;
+    return !!s?.active && s.tracedTabs.has(targetId);
+  }
+
+  /** Get shortId for a tab being traced, for building trace entries. */
+  getTabShortId(targetId: string): string | undefined {
+    return this.tabs.get(targetId)?.shortId;
+  }
+
+  /** Infer which action likely triggered a network request (heuristic). */
+  inferTriggerSeq(requestTs: number): number | undefined {
+    const tl = this.traceSession?.timeline;
+    if (!tl) return undefined;
+    for (let i = tl.length - 1; i >= 0; i--) {
+      const e = tl[i];
+      if (e.type !== 'action') continue;
+      if (requestTs - e.ts < 2000) return e.seq;
+      break; // action is too old
+    }
+    return undefined;
   }
 }

--- a/packages/shared/src/commands.ts
+++ b/packages/shared/src/commands.ts
@@ -344,11 +344,16 @@ export const COMMANDS: CommandDef[] = [
   },
   {
     method: "trace", group: "debug",
-    description: "Record user interactions for replay or code generation",
-    requiresTab: true,
+    description: "Record a unified timeline of actions + network requests for site adapter creation",
+    requiresTab: false,
     params: {
-      traceCommand: { type: "string", required: true, position: 0, description: "Trace sub-command (start/stop/status)" },
-      tab: { type: "string", required: true, description: "Tab short ID" },
+      traceCommand: { type: "string", required: true, position: 0, description: "Trace sub-command (start/stop/status/events/body)" },
+      tab: { type: "string", required: false, description: "Tab short ID (start: trace only this tab; events: filter by tab)" },
+      since: { type: "string", required: false, description: "Incremental query cursor (seq number)" },
+      type: { type: "string", required: false, description: "Filter by event type: action, request, response, navigation" },
+      filter: { type: "string", required: false, description: "URL or text substring filter" },
+      limit: { type: "number", required: false, description: "Max number of events to return" },
+      requestId: { type: "string", required: false, description: "Request ID (for trace body)" },
     },
   },
 ];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,7 +16,11 @@ export {
   type ResponseError,
   type SnapshotData,
   type TabInfo,
-  type TraceEvent,
+  type TraceEntry,
+  type TraceAction,
+  type TraceRequest,
+  type TraceResponse,
+  type TraceNavigation,
   type TraceStatus,
 } from "./protocol.js";
 

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -91,8 +91,12 @@ export interface Request {
   consoleCommand?: "get" | "clear";
   /** errors 子命令：get, clear */
   errorsCommand?: "get" | "clear";
-  /** trace 子命令：start, stop, status */
-  traceCommand?: "start" | "stop" | "status";
+  /** trace 子命令：start, stop, status, events, body */
+  traceCommand?: "start" | "stop" | "status" | "events" | "body";
+  /** Request ID for trace body command */
+  requestId?: string;
+  /** Event type filter for trace events (action/request/response/navigation) */
+  traceType?: string;
   /** 按键名（press 命令使用） */
   key?: string;
   /** 修饰键列表（press 命令使用） */
@@ -198,49 +202,91 @@ export interface JSErrorInfo {
   timestamp: number;
 }
 
-/** Trace 事件类型 - 录制用户操作 */
-export interface TraceEvent {
-  /** 事件类型 */
-  type: 'click' | 'fill' | 'select' | 'check' | 'press' | 'scroll' | 'navigation';
-  /** 时间戳 */
-  timestamp: number;
-  /** 事件发生时的页面 URL */
-  url: string;
-  
-  /** 元素引用 - highlightIndex，可直接用于 @ref */
-  ref?: number;
-  /** 备用定位 - XPath */
-  xpath?: string;
-  /** CSS 选择器 */
-  cssSelector?: string;
-  
-  /** 操作参数 - fill/select 的值 */
-  value?: string;
-  /** 操作参数 - press 的按键 */
-  key?: string;
-  /** 操作参数 - scroll 方向 */
-  direction?: 'up' | 'down' | 'left' | 'right';
-  /** 操作参数 - scroll 距离 */
-  pixels?: number;
-  /** 操作参数 - check/uncheck 状态 */
-  checked?: boolean;
-  
-  /** 语义信息 - 元素角色 */
-  elementRole?: string;
-  /** 语义信息 - 元素名称 */
-  elementName?: string;
-  /** 语义信息 - 元素标签 */
-  elementTag?: string;
+// ---------------------------------------------------------------------------
+// Trace — unified timeline of actions + network + navigation
+// ---------------------------------------------------------------------------
+
+/** Base fields shared by all trace entries */
+interface TraceEntryBase {
+  /** Global monotonic seq */
+  seq: number;
+  /** Millisecond timestamp (Date.now()) */
+  ts: number;
+  /** Tab shortId where the event occurred */
+  tab: string;
 }
 
-/** Trace 录制状态 */
+/** User action (bb-browser command or human interaction) */
+export interface TraceAction extends TraceEntryBase {
+  type: 'action';
+  /** Whether this action came from a bb-browser command or human interaction */
+  source: 'command' | 'human';
+  /** Action name: click, fill, type, press, scroll, select, check, open, ... */
+  action: string;
+  /** Element ref from snapshot */
+  ref?: number;
+  /** CSS selector (for human-captured events) */
+  selector?: string;
+  /** Visible text of the target element (truncated) */
+  text?: string;
+  /** Accessibility role */
+  role?: string;
+  /** HTML tag name */
+  tag?: string;
+  /** Input value (fill/type) */
+  value?: string;
+  /** Key name (press) */
+  key?: string;
+  /** Scroll direction */
+  direction?: string;
+  /** URL (for open/navigation actions) */
+  url?: string;
+}
+
+/** Network request sent */
+export interface TraceRequest extends TraceEntryBase {
+  type: 'request';
+  requestId: string;
+  method: string;
+  url: string;
+  /** Resource type: XHR, Fetch, Document, Script, ... */
+  resourceType: string;
+  headers?: Record<string, string>;
+  /** POST body */
+  body?: string;
+  /** Seq of the action that likely triggered this request */
+  triggerSeq?: number;
+}
+
+/** Network response received */
+export interface TraceResponse extends TraceEntryBase {
+  type: 'response';
+  /** Matches TraceRequest.requestId */
+  requestId: string;
+  status: number;
+  mimeType?: string;
+  bodySize?: number;
+}
+
+/** Page navigation */
+export interface TraceNavigation extends TraceEntryBase {
+  type: 'navigation';
+  url: string;
+  /** URL before navigation */
+  from?: string;
+}
+
+/** Union of all trace entry types */
+export type TraceEntry = TraceAction | TraceRequest | TraceResponse | TraceNavigation;
+
+/** Trace session status */
 export interface TraceStatus {
-  /** 是否正在录制 */
+  /** Whether recording is active */
   recording: boolean;
-  /** 已录制事件数量 */
+  /** Total event count in the timeline */
   eventCount: number;
-  /** 录制的标签页 ID */
-  tabId?: number;
+  /** Tabs being traced */
+  tracedTabs?: string[];
 }
 
 /** 响应数据 */
@@ -299,10 +345,12 @@ export interface ResponseData {
   consoleMessages?: ConsoleMessageInfo[];
   /** JS 错误列表（errors 命令返回） */
   jsErrors?: JSErrorInfo[];
-  /** Trace 事件列表（trace stop 命令返回） */
-  traceEvents?: TraceEvent[];
-  /** Trace 录制状态（trace status 命令返回） */
+  /** Trace timeline entries (trace events/stop command) */
+  traceEvents?: TraceEntry[];
+  /** Trace session status */
   traceStatus?: TraceStatus;
+  /** Trace response body (trace body command) */
+  traceBody?: { requestId: string; body: string; base64Encoded: boolean };
 }
 
 /** 错误信息 */


### PR DESCRIPTION
## 背景

创建 site adapter 时，需要理解"用户操作 → 网络请求"的因果关系。现有的 `trace` 命令是空壳（`traceEvents` 永远为空），`recordAction()` 只存最后一个 seq 数字，人工在 Chrome 里的操作完全不可见。

## 改动

### 1. 统一时间线（`feat(trace)`）

将空壳 `trace` 命令改造为完整的录制系统，在同一条时间线里记录：

- **命令式操作**（click/fill/press/scroll 等）—— 改造 `recordAction()` 传入操作详情
- **人工操作**（用户直接在 Chrome 里点击/输入）—— 通过 `Runtime.addBinding` + 注入 JS 监听器捕获
- **网络请求/响应** —— CDP Network 事件推入 trace timeline
- **因果推断** —— 每个 request 自动关联最近的 action（`triggerSeq`）

新增子命令：
- `trace events` —— 查询时间线，支持 `--tab`/`--type`/`--since`/`--filter`/`--limit`
- `trace body <requestId>` —— 获取某个请求的 response body

设计要点：
- trace 是 **session 级别**，非 per-tab。新 tab 通过 `Target.targetCreated` 的 `openerId` 自动加入
- `trace stop` 只停止采集，数据保留，可反复查询
- 现有 `network`/`console`/`errors` 命令零改动，完全向后兼容

### 2. 修复页面导航后网络事件丢失（`fix(cdp)`）

**这是一个长期存在的 bug，不限于 trace 功能。**

根因：`Target.detachedFromTarget` 在同 tab 跨域导航时被触发，handler 误调 `tabManager.removeTab()`，导致 tab 的所有 event buffer（network/console/errors）被销毁。新 session attach 后事件无处写入，被静默丢弃。

修复：
- `Target.detachedFromTarget`：只清 session 映射，不删 tab state。tab 删除交给 `Target.targetDestroyed`
- `Target.attachedToTarget`：检测到已有 tab 时，重新 enable CDP domains（Network/Page/Runtime/DOM/Accessibility）

### 3. Help text 更新

CLI help 和选项说明同步更新。

## 改动文件

| 文件 | 改动 |
|------|------|
| `protocol.ts` | `TraceEvent` → `TraceEntry` union 类型；Request 新增 traceType/requestId；ResponseData 新增 traceBody |
| `index.ts` (shared) | 导出新类型 |
| `commands.ts` | trace 扩展为 5 个子命令 + 过滤参数 |
| `tab-state.ts` | TraceSession + ActionDetail 类型；recordAction() 接受 detail；TabStateManager 新增 trace 方法 |
| `command-dispatch.ts` | trace handler 重写；~15 个 recordAction() 调用传入操作详情 |
| `cdp-connection.ts` | Network/Response 推入 trace；人工操作捕获；新 tab 自动加入；导航 fix |
| `trace.ts` (cli) | 格式化时间线输出 |
| `index.ts` (cli) | help text + 新 flag 解析 |

## 验证

- [x] 编译通过
- [x] 现有测试通过（1 个 pre-existing failure 无关）
- [x] action 录制（command + human）
- [x] network 请求 + triggerSeq 因果关联
- [x] trace events 查询 + 过滤（--type/--since/--tab）
- [x] trace body 获取 response body
- [x] 同域导航后 network events 正常
- [x] 跨域导航后 network events 正常（HN → example.com）
- [x] 向后兼容：`network requests` 等命令不受影响

## Agent 使用示例

```bash
# 开始录制
bb-browser trace start --tab 58b0

# 操作
bb-browser snap --tab 58b0
bb-browser click 11 --tab 58b0
bb-browser fill 3 "搜索关键词" --tab 58b0
bb-browser press Enter --tab 58b0

# 查看时间线
bb-browser trace events
bb-browser trace events --type request    # 只看网络请求
bb-browser trace events --since 20        # 增量查询

# 获取请求 body
bb-browser trace body <requestId>

# 停止（数据保留）
bb-browser trace stop
bb-browser trace events                   # 停后仍可查询
```