### PR TITLE
feat(dx): goto、cookies、source grep、--exclude-static 等 6 项开发者体验改进

### DIFF
--- a/packages/cli/src/commands/cookies.ts
+++ b/packages/cli/src/commands/cookies.ts
@@ -1,0 +1,57 @@
+/**
+ * cookies 命令 - 查看当前页面的 cookies
+ *
+ * 用法：
+ *   bb-browser cookies --tab <tabId>
+ *   bb-browser cookies --tab <tabId> --filter <name-or-domain>
+ */
+
+import type { Request, Response } from "@bb-browser/shared";
+import { sendCommand } from "../client.js";
+
+export interface CookiesOptions {
+  json?: boolean;
+  tabId?: string | number;
+  filter?: string;
+}
+
+export async function cookiesCommand(
+  options: CookiesOptions = {}
+): Promise<void> {
+  const request: Request = {
+    method: "cookies",
+    tabId: options.tabId,
+    filter: options.filter,
+  };
+
+  const response: Response = await sendCommand(request);
+
+  if (options.json) {
+    console.log(JSON.stringify(response));
+    return;
+  }
+
+  if (response.error) {
+    throw new Error(response.error.message || "Cookies command failed");
+  }
+
+  const data = response.result;
+  const cookies = (data as any)?.cookies || [];
+
+  if (cookies.length === 0) {
+    console.log("No cookies found");
+    return;
+  }
+
+  console.log(`Cookies (${cookies.length}):\n`);
+  for (const c of cookies) {
+    const flags: string[] = [];
+    if (c.httpOnly) flags.push("httpOnly");
+    if (c.secure) flags.push("secure");
+    const expiresStr = c.expires > 0
+      ? `expires=${new Date(c.expires * 1000).toISOString().split("T")[0]}`
+      : "session";
+    const flagStr = flags.length > 0 ? `  ${flags.join("  ")}` : "";
+    console.log(`name=${c.name}  domain=${c.domain}  path=${c.path}${flagStr}  ${expiresStr}`);
+  }
+}

--- a/packages/cli/src/commands/goto.ts
+++ b/packages/cli/src/commands/goto.ts
@@ -1,0 +1,46 @@
+/**
+ * goto 命令 - 在当前 tab 中导航到新 URL（保持 tab 上下文）
+ *
+ * 用法：
+ *   bb-browser goto <url> --tab <tabId>
+ */
+
+import type { Request, Response } from "@bb-browser/shared";
+import { sendCommand } from "../client.js";
+import { ensureDaemonRunning } from "../daemon-manager.js";
+
+export interface GotoOptions {
+  json?: boolean;
+  tabId?: string | number;
+}
+
+export async function gotoCommand(
+  url: string,
+  options: GotoOptions = {}
+): Promise<void> {
+  if (!url) {
+    throw new Error("Missing URL parameter");
+  }
+
+  await ensureDaemonRunning();
+
+  const request: Request = {
+    method: "goto",
+    url,
+    tabId: options.tabId,
+  };
+
+  const response: Response = await sendCommand(request);
+
+  if (options.json) {
+    console.log(JSON.stringify(response, null, 2));
+  } else {
+    if (response.result) {
+      console.log(`tab: ${response.result.tab}`);
+      console.log(`url: ${response.result.url}`);
+    } else {
+      console.error(`Error: ${response.error?.message}`);
+      process.exit(1);
+    }
+  }
+}

--- a/packages/cli/src/commands/network.ts
+++ b/packages/cli/src/commands/network.ts
@@ -14,6 +14,7 @@ interface NetworkOptions {
   since?: string;
   method?: string;
   status?: string;
+  excludeStatic?: boolean;
 }
 
 export async function networkCommand(
@@ -37,6 +38,7 @@ export async function networkCommand(
       body: options.body,
     } : undefined,
     withBody: subCommand === "requests" ? options.withBody : undefined,
+    excludeStatic: subCommand === "requests" ? options.excludeStatic : undefined,
     since,
     httpMethod: subCommand === "requests" ? options.method : undefined,
     status: subCommand === "requests" ? options.status : undefined,

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -65,17 +65,18 @@ export async function openCommand(
     console.log(JSON.stringify(response, null, 2));
   } else {
     if (response.result) {
-      console.log(`已打开: ${response.result?.url ?? normalizedUrl}`);
-      if (response.result?.title) {
-        console.log(`标题: ${response.result.title}`);
+      const tab = response.result?.tab;
+      if (tab) {
+        console.log(`tab: ${tab}`);
       }
-      if (response.result?.tabId) {
-        console.log(`Tab ID: ${response.result.tabId}`);
+      console.log(`url: ${response.result?.url ?? normalizedUrl}`);
+      if (response.result?.title) {
+        console.log(`title: ${response.result.title}`);
       }
       // 提示：如果该域名有 site adapter，引导使用
       const siteHint = getSiteHintForDomain(normalizedUrl);
       if (siteHint) {
-        console.log(`\n💡 ${siteHint}`);
+        console.log(`\nhint: ${siteHint}`);
       }
     } else {
       console.error(`错误: ${response.error?.message}`);

--- a/packages/cli/src/commands/source.ts
+++ b/packages/cli/src/commands/source.ts
@@ -1,0 +1,58 @@
+/**
+ * source 命令 - 搜索已加载的 JavaScript 源码
+ *
+ * 用法：
+ *   bb-browser source grep <pattern> --tab <tabId>
+ */
+
+import type { Request, Response } from "@bb-browser/shared";
+import { sendCommand } from "../client.js";
+
+export interface SourceOptions {
+  json?: boolean;
+  tabId?: string | number;
+}
+
+export async function sourceCommand(
+  subCommand: string,
+  pattern: string,
+  options: SourceOptions = {}
+): Promise<void> {
+  const request: Request = {
+    method: "source",
+    sourceCommand: subCommand,
+    sourcePattern: pattern,
+    tabId: options.tabId,
+  };
+
+  const response: Response = await sendCommand(request);
+
+  if (options.json) {
+    console.log(JSON.stringify(response));
+    return;
+  }
+
+  if (response.error) {
+    throw new Error(response.error.message || "Source command failed");
+  }
+
+  const data = response.result;
+  const results = (data as any)?.sourceResults || [];
+
+  if (results.length === 0) {
+    console.log(`No matches found for "${pattern}"`);
+    return;
+  }
+
+  let totalMatches = 0;
+  for (const result of results) {
+    totalMatches += result.matches.length;
+    console.log(`=== ${result.url} (${result.matches.length} matches) ===`);
+    for (const match of result.matches) {
+      console.log(`  ${match}`);
+    }
+    console.log("");
+  }
+
+  console.log(`${totalMatches} matches in ${results.length} files`);
+}

--- a/packages/cli/src/commands/trace.ts
+++ b/packages/cli/src/commands/trace.ts
@@ -13,6 +13,7 @@ interface TraceOptions {
   filter?: string;
   limit?: number;
   requestId?: string;
+  excludeStatic?: boolean;
 }
 
 export async function traceCommand(
@@ -31,6 +32,7 @@ export async function traceCommand(
     if (options.type) request.traceType = options.type;
     if (options.filter) request.filter = options.filter;
     if (options.limit) request.limit = Number(options.limit);
+    if (options.excludeStatic) request.excludeStatic = true;
   }
 
   // body-specific params
@@ -137,10 +139,20 @@ export async function traceCommand(
         console.error("No body data returned");
         break;
       }
-      if (body.base64Encoded) {
-        console.log(`[base64 encoded, ${body.body.length} chars]`);
-      } else {
-        console.log(body.body);
+      if (body.requestBody) {
+        console.log("=== Request Body ===");
+        console.log(body.requestBody);
+        console.log("");
+      }
+      if (body.body) {
+        if (body.requestBody) {
+          console.log("=== Response Body ===");
+        }
+        if (body.base64Encoded) {
+          console.log(`[base64 encoded, ${body.body.length} chars]`);
+        } else {
+          console.log(body.body);
+        }
       }
       break;
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { openCommand } from "./commands/open.js";
+import { gotoCommand } from "./commands/goto.js";
 import { snapshotCommand } from "./commands/snapshot.js";
 import { clickCommand } from "./commands/click.js";
 import { hoverCommand } from "./commands/hover.js";
@@ -24,6 +25,8 @@ import { networkCommand } from "./commands/network.js";
 import { consoleCommand } from "./commands/console.js";
 import { errorsCommand } from "./commands/errors.js";
 import { traceCommand } from "./commands/trace.js";
+import { cookiesCommand } from "./commands/cookies.js";
+import { sourceCommand as sourceCmd } from "./commands/source.js";
 import { siteCommand } from "./commands/site.js";
 import { shutdownCommand, startCommand, statusCommand } from "./commands/daemon.js";
 import { getDaemonPath } from "./daemon-manager.js";
@@ -39,6 +42,7 @@ const TAB_REQUIRED_COMMANDS = new Set([
   "click", "hover", "fill", "type", "check", "uncheck", "select",
   "press", "scroll", "back", "forward", "reload", "close",
   "frame", "dialog", "network", "console", "errors",
+  "goto", "cookies", "source",
 ]);
 
 // eval requires --tab unless --domain is provided
@@ -67,7 +71,8 @@ bb-browser - AI Agent 浏览器自动化工具
   star                         ⭐ Star bb-browser on GitHub
 
 浏览器操作：
-  open <url> [--tab]           打开 URL
+  open <url> [--tab]           打开 URL（新 tab 或指定 tab）
+  goto <url> --tab <id>        在当前 tab 导航到新 URL（保持上下文）
   snap [-i] [-c] [-d <n>]     获取页面快照 (--tab required)
   click <ref>                  点击元素 (--tab required)
   hover <ref>                  悬停元素 (--tab required)
@@ -93,6 +98,8 @@ bb-browser - AI Agent 浏览器自动化工具
 
 调试：
   network requests [filter]    查看网络请求 (--tab required)
+  cookies [--filter <str>]     查看页面 cookies (--tab required)
+  source grep <pattern>        搜索已加载 JS 源码 (--tab required)
   console [--clear]            查看/清空控制台 (--tab required)
   errors [--clear]             查看/清空 JS 错误 (--tab required)
   trace start [--tab <id>]     录制操作+网络的统一时间线
@@ -114,7 +121,8 @@ bb-browser - AI Agent 浏览器自动化工具
   --tab <tabId>        指定操作的标签页 ID
   --since <seq>        增量查询（network/console/errors/trace events）
   --type <t>           过滤事件类型（trace events: action/request/response）
-  --filter <str>       URL 或文字过滤（trace events/network requests）
+  --filter <str>       URL 或文字过滤（trace events/network requests/cookies）
+  --exclude-static     排除静态资源（trace events/network requests）
   --limit <n>          限制返回条数
   --request-id <id>    请求 ID（trace body）
   --help, -h           显示帮助信息
@@ -253,6 +261,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       if (nextIdx < args.length) {
         (result.flags as Record<string, unknown>)["request-id"] = args[nextIdx];
       }
+    } else if (arg === "--exclude-static") {
+      (result.flags as Record<string, unknown>).excludeStatic = true;
     } else if (arg.startsWith("-")) {
       // Unknown flags, ignore
     } else if (result.command === null) {
@@ -326,6 +336,16 @@ async function main(): Promise<void> {
         const tabIndex = process.argv.findIndex(a => a === "--tab");
         const tab = tabIndex >= 0 ? process.argv[tabIndex + 1] : undefined;
         await openCommand(url, { json: parsed.flags.json, tab });
+        break;
+      }
+
+      case "goto": {
+        const gotoUrl = parsed.args[0];
+        if (!gotoUrl) {
+          console.error("用法：bb-browser goto <url> --tab <tabId>");
+          process.exit(1);
+        }
+        await gotoCommand(gotoUrl, { json: parsed.flags.json, tabId: globalTabId });
         break;
       }
 
@@ -575,7 +595,8 @@ async function main(): Promise<void> {
         const method = methodIndex >= 0 ? process.argv[methodIndex + 1] : undefined;
         const statusIndex = process.argv.findIndex(a => a === "--status");
         const statusFilter = statusIndex >= 0 ? process.argv[statusIndex + 1] : undefined;
-        await networkCommand(subCommand, urlOrFilter, { json: parsed.flags.json, abort, body, withBody, tabId: globalTabId, since: globalSince, method, status: statusFilter });
+        const excludeStatic = process.argv.includes("--exclude-static");
+        await networkCommand(subCommand, urlOrFilter, { json: parsed.flags.json, abort, body, withBody, tabId: globalTabId, since: globalSince, method, status: statusFilter, excludeStatic });
         break;
       }
 
@@ -588,6 +609,27 @@ async function main(): Promise<void> {
       case "errors": {
         const clear = process.argv.includes("--clear");
         await errorsCommand({ json: parsed.flags.json, clear, tabId: globalTabId, since: globalSince });
+        break;
+      }
+
+      case "cookies": {
+        const f = parsed.flags as Record<string, unknown>;
+        await cookiesCommand({
+          json: parsed.flags.json,
+          tabId: globalTabId,
+          filter: f.filter as string | undefined,
+        });
+        break;
+      }
+
+      case "source": {
+        const srcSubCmd = parsed.args[0];
+        const srcPattern = parsed.args[1];
+        if (!srcSubCmd || !srcPattern) {
+          console.error("用法：bb-browser source grep <pattern> --tab <tabId>");
+          process.exit(1);
+        }
+        await sourceCmd(srcSubCmd, srcPattern, { json: parsed.flags.json, tabId: globalTabId });
         break;
       }
 
@@ -606,6 +648,7 @@ async function main(): Promise<void> {
           filter: f.filter as string | undefined,
           limit: f.limit as number | undefined,
           requestId: (f["request-id"] as string | undefined) || parsed.args[1],
+          excludeStatic: f.excludeStatic as boolean | undefined,
         });
         break;
       }

--- a/packages/daemon/src/command-dispatch.ts
+++ b/packages/daemon/src/command-dispatch.ts
@@ -498,6 +498,16 @@ async function getAttributeValue(
   return String(call.result.value ?? "");
 }
 
+// ---------------------------------------------------------------------------
+// Static asset detection (shared by trace --exclude-static and network --exclude-static)
+// ---------------------------------------------------------------------------
+
+function isStaticAsset(url: string): boolean {
+  if (url.includes("/_next/static/")) return true;
+  const ext = url.split("?")[0].split("#")[0].split(".").pop()?.toLowerCase();
+  return ["js", "css", "png", "jpg", "jpeg", "gif", "svg", "ico", "woff", "woff2", "ttf", "eot", "map"].includes(ext || "");
+}
+
 // Trace state is now managed by TabStateManager.traceSession
 
 // ---------------------------------------------------------------------------
@@ -664,6 +674,20 @@ export async function dispatchRequest(
         tab: shortId,
         seq,
       });
+    }
+
+    case "goto": {
+      if (!request.url) return fail("Missing url");
+      let url = request.url;
+      if (!url.startsWith("http://") && !url.startsWith("https://")) {
+        url = "https://" + url;
+      }
+      const seq = tab.recordAction({ action: "goto", url });
+      await cdp.pageCommand(target.id, "Page.navigate", { url });
+      // Wait briefly for navigation
+      await new Promise(r => setTimeout(r, 500));
+      tab.refs = {};
+      return ok({ tab: shortId, seq, url });
     }
 
     case "back": {
@@ -1000,7 +1024,12 @@ export async function dispatchRequest(
             limit: request.limit,
           });
 
-          const items = queryResult.items;
+          let items = queryResult.items;
+
+          // Exclude static assets if requested
+          if (request.excludeStatic) {
+            items = items.filter(item => !isStaticAsset(item.url));
+          }
           // Fetch response bodies if requested
           if (request.withBody) {
             await Promise.all(
@@ -1163,6 +1192,24 @@ export async function dispatchRequest(
             events = events.filter(e => e.seq > threshold);
           }
 
+          // Exclude static assets (both requests and their responses)
+          if (request.excludeStatic) {
+            const excludedRequestIds = new Set<string>();
+            events = events.filter((e: TraceEntry) => {
+              if (e.type === "request") {
+                if (isStaticAsset(e.url)) {
+                  excludedRequestIds.add(e.requestId);
+                  return false;
+                }
+                return true;
+              }
+              if (e.type === "response") {
+                return !excludedRequestIds.has(e.requestId);
+              }
+              return true;
+            });
+          }
+
           // Text/URL filter
           if (request.filter) {
             const f = request.filter.toLowerCase();
@@ -1204,17 +1251,131 @@ export async function dispatchRequest(
               "Network.getResponseBody",
               { requestId: request.requestId },
             );
+            // Also include request body from trace timeline if available
+            const traceRequestBody = reqEntry.body;
             return ok({
-              traceBody: { requestId: request.requestId, body: body.body, base64Encoded: body.base64Encoded },
+              traceBody: {
+                requestId: request.requestId,
+                body: body.body,
+                base64Encoded: body.base64Encoded,
+                requestBody: traceRequestBody,
+              },
               tab: shortId,
             });
           } catch (error) {
+            // Even if response body fetch fails, try to return the request body
+            const traceRequestBody = reqEntry.body;
+            if (traceRequestBody) {
+              return ok({
+                traceBody: {
+                  requestId: request.requestId,
+                  body: "",
+                  base64Encoded: false,
+                  requestBody: traceRequestBody,
+                },
+                tab: shortId,
+              });
+            }
             return fail(error);
           }
         }
         default:
           return fail(`Unknown trace subcommand: ${subCommand}`);
       }
+    }
+
+    // -----------------------------------------------------------------------
+    // Cookies
+    // -----------------------------------------------------------------------
+    case "cookies": {
+      const seq = tab.recordAction({ action: "cookies" });
+      const { cookies } = await cdp.sessionCommand<{ cookies: any[] }>(target.id, "Network.getCookies", {});
+      let filtered = cookies;
+      if (request.filter) {
+        const f = request.filter.toLowerCase();
+        filtered = cookies.filter((c: any) =>
+          c.name.toLowerCase().includes(f) || c.domain.toLowerCase().includes(f)
+        );
+      }
+      return ok({
+        tab: shortId,
+        seq,
+        cookies: filtered.map((c: any) => ({
+          name: c.name,
+          value: c.value,
+          domain: c.domain,
+          path: c.path,
+          expires: c.expires,
+          httpOnly: c.httpOnly,
+          secure: c.secure,
+        })),
+      });
+    }
+
+    // -----------------------------------------------------------------------
+    // Source search
+    // -----------------------------------------------------------------------
+    case "source": {
+      const subCmd = request.sourceCommand;
+      if (subCmd !== "grep") return fail("Unknown source subcommand. Use: source grep <pattern>");
+      const pattern = request.sourcePattern;
+      if (!pattern) return fail("Missing search pattern");
+
+      const seq = tab.recordAction({ action: "source", url: `grep ${pattern}` });
+
+      // Get all frames and their resources
+      const { frameTree } = await cdp.sessionCommand<any>(target.id, "Page.getResourceTree", {});
+
+      // Collect all script URLs from the resource tree
+      const scripts: { url: string; frameId: string }[] = [];
+      function collectScripts(node: any) {
+        if (node.resources) {
+          for (const r of node.resources) {
+            if (r.type === "Script" && r.url && !r.url.startsWith("data:")) {
+              scripts.push({ url: r.url, frameId: node.frame.id });
+            }
+          }
+        }
+        if (node.childFrames) {
+          for (const child of node.childFrames) collectScripts(child);
+        }
+      }
+      collectScripts(frameTree);
+
+      // Search each script
+      const sourceResults: { url: string; matches: string[] }[] = [];
+      for (const script of scripts) {
+        try {
+          const { content } = await cdp.sessionCommand<{ content: string }>(
+            target.id, "Page.getResourceContent",
+            { frameId: script.frameId, url: script.url }
+          );
+          if (!content) continue;
+
+          // Find all lines containing the pattern
+          const regex = new RegExp(pattern, "gi");
+          const lines = content.split("\n");
+          const matches: string[] = [];
+          for (const line of lines) {
+            if (regex.test(line)) {
+              // Extract a short context around the match (trim to 200 chars)
+              const trimmed = line.trim().slice(0, 200);
+              matches.push(trimmed);
+              regex.lastIndex = 0; // Reset regex state
+            }
+          }
+          if (matches.length > 0) {
+            // Shorten URL for display
+            const shortUrl = script.url.replace(/^https?:\/\/[^/]+/, "");
+            sourceResults.push({ url: shortUrl, matches });
+          }
+        } catch {
+          // Skip scripts that can't be fetched (e.g., cross-origin)
+          continue;
+        }
+      }
+
+      return ok({ tab: shortId, seq, sourceResults });
     }
 
     // -----------------------------------------------------------------------

--- a/packages/shared/src/commands.ts
+++ b/packages/shared/src/commands.ts
@@ -50,6 +50,15 @@ export const COMMANDS: CommandDef[] = [
     },
   },
   {
+    method: "goto", group: "navigate",
+    description: "Navigate current tab to a URL (keeps tab context)",
+    requiresTab: true,
+    params: {
+      url: { type: "string", required: true, position: 0, description: "URL to navigate to" },
+      tab: { type: "string", required: false, description: "Tab ID" },
+    },
+  },
+  {
     method: "back", group: "navigate",
     description: "Navigate back in browser history",
     requiresTab: true,
@@ -315,6 +324,7 @@ export const COMMANDS: CommandDef[] = [
       status: { type: "string", required: false, description: "Filter by status: '4xx', '5xx', or exact code like '200'" },
       limit: { type: "number", required: false, description: "Max number of results to return" },
       withBody: { type: "boolean", required: false, description: "Include request and response bodies" },
+      excludeStatic: { type: "boolean", required: false, description: "Exclude static assets (.js, .css, .png, etc.)" },
       tab: { type: "string", required: true, description: "Tab short ID" },
     },
   },
@@ -354,6 +364,26 @@ export const COMMANDS: CommandDef[] = [
       filter: { type: "string", required: false, description: "URL or text substring filter" },
       limit: { type: "number", required: false, description: "Max number of events to return" },
       requestId: { type: "string", required: false, description: "Request ID (for trace body)" },
+      excludeStatic: { type: "boolean", required: false, description: "Exclude static assets (.js, .css, .png, etc.)" },
+    },
+  },
+  {
+    method: "cookies", group: "debug",
+    description: "List cookies for the current page",
+    requiresTab: true,
+    params: {
+      tab: { type: "string", required: false, description: "Tab ID" },
+      filter: { type: "string", required: false, description: "Filter by cookie name or domain" },
+    },
+  },
+  {
+    method: "source", group: "debug",
+    description: "Search loaded JavaScript sources (e.g. source grep '/api/')",
+    requiresTab: true,
+    params: {
+      sourceCommand: { type: "string", required: true, position: 0, description: "Subcommand: grep" },
+      sourcePattern: { type: "string", required: true, position: 1, description: "Search pattern (string or regex)" },
+      tab: { type: "string", required: false, description: "Tab ID" },
     },
   },
 ];

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -34,7 +34,10 @@ export type ActionType =
   | "site_run"
   | "site_list"
   | "site_info"
-  | "site_search";
+  | "site_search"
+  | "goto"
+  | "cookies"
+  | "source";
 
 /** 请求类型 */
 export interface Request {
@@ -121,6 +124,12 @@ export interface Request {
   query?: string;
   /** 是否包含 base64 数据（screenshot 命令使用） */
   includeBase64?: boolean;
+  /** 排除静态资源（trace events / network requests 使用） */
+  excludeStatic?: boolean;
+  /** source 子命令：grep */
+  sourceCommand?: string;
+  /** source 搜索模式 */
+  sourcePattern?: string;
 }
 
 /** 元素引用信息 */
@@ -350,7 +359,11 @@ export interface ResponseData {
   /** Trace session status */
   traceStatus?: TraceStatus;
   /** Trace response body (trace body command) */
-  traceBody?: { requestId: string; body: string; base64Encoded: boolean };
+  traceBody?: { requestId: string; body: string; base64Encoded: boolean; requestBody?: string };
+  /** Cookies for the current page (cookies command) */
+  cookies?: Array<{ name: string; value: string; domain: string; path: string; expires: number; httpOnly: boolean; secure: boolean }>;
+  /** Source grep results (source command) */
+  sourceResults?: Array<{ url: string; matches: string[] }>;
 }
 
 /** 错误信息 */


### PR DESCRIPTION
## 背景

用 bb-browser 探索 cms.rflow.ai 并逆向其 API 的过程中，发现了多个工具链缺失和体验痛点：

- 没有在已有 tab 导航的命令，只能 `eval "window.location.href=..."` 破坏 SPA 路由
- trace/network 被静态资源淹没，找 API 调用如大海捞针
- 发现 API 端点需要手动下载 JS chunks 再 grep，没有内置工具
- 看 cookie 需要 `eval "document.cookie"`，没有专用命令
- `open` 返回 32 位长 ID，需要再查 `status` 才知道短 ID

## 新增命令

### `goto <url> --tab <id>`
在已有 tab 中导航，使用 `Page.navigate`，不开新 tab。关键用途：SPA 中导航不丢失上下文。

```bash
bb-browser goto "https://example.com/dashboard" --tab 88aa
# tab: 88aa
# url: https://example.com/dashboard
```

### `cookies --tab <id> [--filter <str>]`
查看页面 cookies（`Network.getCookies`），支持按名称/域名过滤。

```bash
bb-browser cookies --tab 88aa
# Cookies (1):
# name=cms-token  domain=cms.rflow.ai  path=/  expires=2026-06-07

bb-browser cookies --tab 88aa --filter token
```

### `source grep <pattern> --tab <id>`
搜索已加载的 JS 源码。使用 `Page.getResourceTree` + `Page.getResourceContent` 获取所有脚本内容，用正则搜索。这是 SPA API 发现的杀手级功能。

```bash
bb-browser source grep "/rflow-cms/api" --tab 88aa
# === /_next/static/chunks/pages/seo/topic-e2b7ca90f307dc0a.js (1 matches) ===
#   e.post("/rflow-cms/api/topic",t)
```

## 改进

### `--exclude-static` 过滤

`trace events` 和 `network requests` 新增 `--exclude-static` 标志，过滤掉 `.js/.css/.png/.woff/.svg/.ico` 以及 `_next/static/` 路径。trace 同时过滤匹配的 response 事件。

```bash
# 不过滤：35 events（全是 .js）
bb-browser trace events

# 过滤后：3 events（action + HTML 请求/响应）
bb-browser trace events --exclude-static

# network 也支持
bb-browser network requests --tab 88aa --exclude-static
```

### trace body 增强
`trace body` 现在同时返回 request body（POST payload）和 response body。

### open 输出短 ID
`open` 命令输出现在显示短 tab ID（如 `88aa`），不再需要查 `status` 才知道。

## 改动文件

| 文件 | 改动 |
|------|------|
| `protocol.ts` | ActionType 新增 goto/cookies/source；Request 新增 excludeStatic/sourceCommand/sourcePattern；ResponseData 新增 cookies/sourceResults/requestBody |
| `commands.ts` | 新增 goto/cookies/source 三个 CommandDef；trace 和 network 新增 excludeStatic 参数 |
| `command-dispatch.ts` | 新增 isStaticAsset() 辅助函数；新增 goto/cookies/source 三个 case；trace events 和 network requests 增加 --exclude-static 过滤（含 response 关联过滤）；trace body 返回 requestBody |
| `goto.ts` (新) | goto CLI 命令 |
| `cookies.ts` (新) | cookies CLI 命令，表格格式化输出 |
| `source.ts` (新) | source grep CLI 命令，按文件分组显示匹配 |
| `index.ts` (cli) | 路由新命令、--exclude-static flag 解析、help text 更新 |
| `open.ts` | 输出格式改为短 ID 优先 |
| `trace.ts` | 传递 excludeStatic；body 子命令显示 request body |
| `network.ts` | 传递 excludeStatic |

## 验证

- [x] 编译通过（pnpm build）
- [x] goto：tab 导航成功，保持上下文
- [x] cookies：正确显示 cms-token cookie
- [x] source grep：找到 JS 中的 API 路径
- [x] trace --exclude-static：35 事件过滤到 3 个（action + HTML 请求/响应）
- [x] network --exclude-static：只显示 Document 请求
- [x] open 输出短 ID
- [x] 向后兼容：不加 --exclude-static 时行为不变