### PR TITLE
feat(clip): add IPC v2 NDJSON clip entry

### DIFF
--- a/bin/bb-browser-clip.ts
+++ b/bin/bb-browser-clip.ts
@@ -1,0 +1,224 @@
+/**
+ * bb-browser-clip — IPC v2 NDJSON clip entry.
+ *
+ * Spawned by an IPC clip host as `bun run <main> --ipc`, cwd = clip dir.
+ * The host acts as the provider; this process implements only the clip side,
+ * speaking the stdin/stdout NDJSON protocol — no Hub connection, no auth.
+ *
+ * Protocol (Pinix-compatible IPC v2 NDJSON over stdio):
+ *   1. On startup, immediately send `register` with the command manifest.
+ *   2. Host replies `registered` (handshake complete).
+ *   3. Host sends `invoke` { id, command, input }; reply with the SAME id as
+ *      `result` (success) or `error` (application failure).
+ *
+ * Transport rules:
+ *   - stdout carries ONLY protocol JSON (one JSON object per line). All logs go
+ *     to stderr — the host re-emits them as `[clip:<name>] ...`.
+ *   - invoke handling does NOT block the read loop (concurrent invokes allowed).
+ *   - application error -> `error` message (message surfaced to caller).
+ *   - internal error    -> crash the process (the host cold-restarts us).
+ *   - stdin closed by the host -> exit (otherwise the bb-browser daemon's
+ *     HTTP keep-alive could pin this process open).
+ */
+
+import { createInterface } from "node:readline";
+import {
+  CommandFailedError,
+  BROWSER_COMMANDS,
+  buildPlatformClips,
+  executeBrowserCommand,
+  executeSiteCommand,
+  zodToJsonSchema,
+  type InputObject,
+} from "./clip-core.ts";
+
+// No @types/node in this project (see bb-browser-provider.ts) — declare the
+// process surface we use. stdin is typed loosely; readline accepts it as-is.
+declare const process: {
+  argv: string[];
+  exit(code?: number): never;
+  on(event: string, listener: (...args: any[]) => void): void;
+  stdin: any;
+  stdout: { write(chunk: string): boolean };
+};
+
+// ---------------------------------------------------------------------------
+// IPC message shape (subset we read/write)
+// ---------------------------------------------------------------------------
+
+interface IpcMessage {
+  id?: string;
+  type: string;
+  command?: string;
+  input?: unknown;
+  output?: unknown;
+  error?: string;
+  manifest?: unknown;
+}
+
+const LOG_PREFIX = "[bb-browser-clip]";
+const SITE_PREFIX = "site.";
+/** JSON Schema string for command outputs (daemon responses are open objects). */
+const OUTPUT_SCHEMA = JSON.stringify({ type: "object", additionalProperties: true });
+
+function logClip(message: string): void {
+  console.error(`${LOG_PREFIX} ${message}`);
+}
+
+function send(msg: IpcMessage): void {
+  process.stdout.write(JSON.stringify(msg) + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// register manifest
+// ---------------------------------------------------------------------------
+
+interface CommandManifestEntry {
+  name: string;
+  description: string;
+  input: string;
+  output: string;
+}
+
+/**
+ * Build the IPC command manifest: all core browser commands plus every site
+ * adapter command namespaced as `site.<platform>.<command>` (one IPC clip can
+ * only register a single command set, so the per-site Hub clips are merged).
+ *
+ * view.* (WebRTC remote viewing) is intentionally omitted — it depends on the
+ * viewer sidecar + TURN, which has no IPC story yet.
+ */
+function buildCommandManifest(): {
+  commands: CommandManifestEntry[];
+  browserCount: number;
+  siteCount: number;
+  platformCount: number;
+} {
+  const browserCommands: CommandManifestEntry[] = BROWSER_COMMANDS.map((cmd) => ({
+    name: cmd.name,
+    description: cmd.description,
+    input: JSON.stringify(zodToJsonSchema(cmd.args)),
+    output: OUTPUT_SCHEMA,
+  }));
+
+  const platformClips = buildPlatformClips();
+  const siteCommands: CommandManifestEntry[] = platformClips.flatMap((pc) =>
+    pc.commands.map((c) => ({
+      name: `${SITE_PREFIX}${pc.alias}.${c.name}`,
+      description: c.description,
+      input: c.inputSchema,
+      output: OUTPUT_SCHEMA,
+    })),
+  );
+
+  return {
+    commands: [...browserCommands, ...siteCommands],
+    browserCount: browserCommands.length,
+    siteCount: siteCommands.length,
+    platformCount: platformClips.length,
+  };
+}
+
+/**
+ * Split a `site.<platform>.<command>` name back into its parts.
+ * <command> may itself contain "." or "/"; <platform> (a top-level site dir
+ * name) never contains ".", so we split on the first dot after the prefix.
+ */
+function parseSiteCommand(command: string): { platform: string; cmd: string } | null {
+  const rest = command.slice(SITE_PREFIX.length); // "<platform>.<command>"
+  const dot = rest.indexOf(".");
+  if (dot <= 0 || dot >= rest.length - 1) return null;
+  return { platform: rest.slice(0, dot), cmd: rest.slice(dot + 1) };
+}
+
+// ---------------------------------------------------------------------------
+// invoke routing
+// ---------------------------------------------------------------------------
+
+/**
+ * Run one invoke and reply with the same id. NEVER awaited by the read loop —
+ * concurrent invokes must not head-of-line block each other on the shared
+ * browser. Application errors are sent as `error`; internal errors re-throw and
+ * become an unhandledRejection (-> deterministic crash -> host cold-restart).
+ */
+async function handleInvoke(msg: IpcMessage): Promise<void> {
+  const input = (msg.input ?? {}) as InputObject;
+  const command = msg.command ?? "";
+  try {
+    let result: unknown;
+    if (command.startsWith(SITE_PREFIX)) {
+      const parsed = parseSiteCommand(command);
+      if (!parsed) throw new CommandFailedError(`Invalid site command: ${command}`);
+      result = await executeSiteCommand(parsed.platform, parsed.cmd, input);
+    } else {
+      result = await executeBrowserCommand(command, input);
+    }
+    send({ id: msg.id, type: "result", output: result });
+  } catch (err) {
+    if (err instanceof CommandFailedError) {
+      // Application error — safe to surface to the caller.
+      send({ id: msg.id, type: "error", error: err.message });
+    } else {
+      // Internal error (daemon won't start, HTTP/CDP transport down, unexpected
+      // throw) — re-throw so the process crashes and the host cold-restarts.
+      throw err;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  // Internal errors must crash deterministically so the host cold-restarts us
+  // (and the in-flight request is reported as internal, not leaked as `error`).
+  process.on("unhandledRejection", (reason: unknown) => {
+    logClip(`unhandledRejection: ${reason instanceof Error ? reason.stack || reason.message : String(reason)}`);
+    process.exit(1);
+  });
+  process.on("uncaughtException", (err: unknown) => {
+    logClip(`uncaughtException: ${err instanceof Error ? err.stack || err.message : String(err)}`);
+    process.exit(1);
+  });
+
+  // Step 1: register FIRST, before any heavy work (the host SIGKILLs us if no
+  // register arrives within 10s). The bb-browser daemon is started lazily on the
+  // first executeBrowserCommand, never before register.
+  const { commands, browserCount, siteCount, platformCount } = buildCommandManifest();
+  send({ type: "register", manifest: { commands } });
+  logClip(
+    `registered ${commands.length} commands (${browserCount} browser, ${siteCount} site across ${platformCount} platforms); view.* skipped (needs viewer sidecar + TURN)`,
+  );
+
+  // Step 2: read loop. Dispatch only — handlers are fire-and-forget so a slow
+  // invoke never blocks the next one.
+  const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+  rl.on("line", (line: string) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    let msg: IpcMessage;
+    try {
+      msg = JSON.parse(trimmed) as IpcMessage;
+    } catch {
+      logClip("failed to parse NDJSON line, skipping");
+      return;
+    }
+    if (!msg.type) return;
+    if (msg.type === "registered") return; // handshake ack — nothing to do
+    if (msg.type === "invoke") {
+      void handleInvoke(msg); // do NOT await — keep the loop free for concurrency
+      return;
+    }
+    // Any other message type (heartbeat, list_clips, ...) is ignored.
+  });
+
+  rl.on("close", () => {
+    // stdin closed by the host = shutdown signal. Exit actively; the
+    // bb-browser daemon's HTTP keep-alive could otherwise pin us open.
+    process.exit(0);
+  });
+}
+
+main();

--- a/bin/clip-core.ts
+++ b/bin/clip-core.ts
@@ -1,0 +1,398 @@
+/**
+ * clip-core — transport-agnostic browser-automation core shared by the
+ * Pinix Hub provider (`bb-browser-provider.ts`) and the IPC clip
+ * (`bb-browser-clip.ts`).
+ *
+ * This module owns everything that is independent of the wire transport:
+ *   - bb-browser daemon connection + command execution
+ *   - site-adapter scanning / namespacing
+ *   - the browser command catalog (zod -> JSON Schema)
+ *
+ * It MUST NOT write to stdout: the IPC clip uses stdout exclusively for the
+ * NDJSON protocol, so all diagnostics here go to stderr.
+ */
+
+import { COMMANDS } from "../packages/shared/src/commands.ts";
+import { COMMAND_TIMEOUT, generateId } from "../packages/shared/src/index.ts";
+import type { Request, Response } from "../packages/shared/src/protocol.ts";
+import {
+  type DaemonInfo,
+  DAEMON_DIR as SHARED_DAEMON_DIR,
+  DAEMON_JSON as SHARED_DAEMON_JSON,
+  readDaemonJson,
+  isProcessAlive,
+  httpJson,
+} from "../packages/shared/src/daemon-client.ts";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { execFile, spawn } from "node:child_process";
+import { join, dirname, resolve, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { z } from "zod";
+
+declare const process: {
+  argv: string[];
+  env: Record<string, string | undefined>;
+  exit(code?: number): never;
+  on(event: string, listener: (...args: unknown[]) => void): void;
+  execPath: string;
+  kill(pid: number, signal: number): void;
+  platform: string;
+};
+
+// ---------------------------------------------------------------------------
+// Logging — stderr only (stdout is reserved for the IPC NDJSON protocol)
+// ---------------------------------------------------------------------------
+
+const CORE_LOG_PREFIX = "[bb-browser-core]";
+
+export function logCore(message: string): void {
+  console.error(`${CORE_LOG_PREFIX} ${message}`);
+}
+
+// ---------------------------------------------------------------------------
+// Error model
+// ---------------------------------------------------------------------------
+
+/**
+ * Application-level command failure — the command ran but failed in a way the
+ * caller can act on (bad URL, element not found, missing tab, site not logged
+ * in, ...). Carries a message that is safe to surface to the caller.
+ *
+ * Anything that is NOT a CommandFailedError (daemon won't start, HTTP/CDP
+ * transport failure, unexpected throw) is an *internal* error: it must
+ * propagate as-is so the IPC clip crashes and the host cold-restarts
+ * it, rather than leaking internal detail as a safe error message.
+ */
+export class CommandFailedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CommandFailedError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Package version
+// ---------------------------------------------------------------------------
+
+function readPackageVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
+    ) as { version?: string };
+    return pkg.version?.trim() || "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+export const CLIP_VERSION = readPackageVersion();
+
+// ---------------------------------------------------------------------------
+// Daemon connection
+// ---------------------------------------------------------------------------
+
+let cachedDaemonInfo: DaemonInfo | null = null;
+let daemonReady = false;
+
+function getDaemonPath(): string {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  const releasePath = resolve(currentDir, "../dist/daemon.js");
+  if (existsSync(releasePath)) return releasePath;
+  return resolve(currentDir, "../packages/daemon/dist/index.js");
+}
+
+/**
+ * Ensure the bb-browser daemon is running, spawning it if necessary.
+ * Throws (internal error) if the daemon cannot be started.
+ */
+export async function ensureDaemon(): Promise<void> {
+  if (daemonReady && cachedDaemonInfo) {
+    try {
+      await httpJson<{ running: boolean }>("GET", "/status", cachedDaemonInfo, undefined, 2000);
+      return;
+    } catch {
+      daemonReady = false;
+      cachedDaemonInfo = null;
+    }
+  }
+  let info = await readDaemonJson();
+  if (info) {
+    if (!isProcessAlive(info.pid)) {
+      try { await unlink(SHARED_DAEMON_JSON); } catch {}
+      info = null;
+    } else {
+      try {
+        const s = await httpJson<{ running?: boolean }>("GET", "/status", info, undefined, 2000);
+        if (s.running) { cachedDaemonInfo = info; daemonReady = true; return; }
+      } catch {}
+    }
+  }
+  const daemonPath = getDaemonPath();
+  const daemonArgs = [daemonPath];
+  if (process.env.CDP_PORT) {
+    daemonArgs.push("--cdp-port", process.env.CDP_PORT);
+  }
+  logCore(`Spawning daemon: ${daemonPath}${process.env.CDP_PORT ? ` --cdp-port ${process.env.CDP_PORT}` : ""}`);
+  const child = spawn(process.execPath, daemonArgs, { detached: true, stdio: "ignore" });
+  child.unref();
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 300));
+    info = await readDaemonJson();
+    if (!info) continue;
+    try {
+      const s = await httpJson<{ running?: boolean }>("GET", "/status", info, undefined, 2000);
+      if (s.running) {
+        cachedDaemonInfo = info;
+        daemonReady = true;
+        logCore(`Daemon ready at ${info.host}:${info.port}`);
+        return;
+      }
+    } catch {}
+  }
+  throw new Error("Daemon did not start in time");
+}
+
+/**
+ * Send a command to the daemon HTTP server. Rejects (internal error) on
+ * transport failure or non-2xx response (e.g. 503 Chrome-not-connected).
+ * A command that ran but failed comes back as HTTP 200 + `{ success: false }`
+ * and is the caller's job to classify (see executeBrowserCommand).
+ */
+export async function daemonCommand(request: Request): Promise<Response> {
+  if (!cachedDaemonInfo) cachedDaemonInfo = await readDaemonJson();
+  if (!cachedDaemonInfo) throw new Error("No daemon.json found. Is the daemon running?");
+  return httpJson<Response>("POST", "/command", cachedDaemonInfo, request, COMMAND_TIMEOUT);
+}
+
+// ---------------------------------------------------------------------------
+// Zod -> JSON Schema (lightweight)
+// ---------------------------------------------------------------------------
+
+export function zodToJsonSchema(schema: z.ZodTypeAny): Record<string, unknown> {
+  return convertZodType(schema);
+}
+
+function convertZodType(schema: z.ZodTypeAny): Record<string, unknown> {
+  const def = (schema as any)._def;
+  const typeName: string = def?.typeName ?? "";
+  if (typeName === "ZodOptional" || typeName === "ZodNullable") {
+    const inner = convertZodType(def.innerType);
+    if (def.description && !inner.description) inner.description = def.description;
+    return inner;
+  }
+  if (typeName === "ZodDefault") {
+    const inner = convertZodType(def.innerType);
+    inner.default = def.defaultValue();
+    if (def.description && !inner.description) inner.description = def.description;
+    return inner;
+  }
+  if (typeName === "ZodEffects") return convertZodType(def.schema);
+  const base: Record<string, unknown> = {};
+  if (def?.description) base.description = def.description;
+  if (typeName === "ZodObject") {
+    const shape = def.shape?.() ?? {};
+    const properties: Record<string, unknown> = {};
+    const required: string[] = [];
+    for (const [key, value] of Object.entries(shape)) {
+      properties[key] = convertZodType(value as z.ZodTypeAny);
+      const innerDef = (value as any)._def;
+      const innerTypeName: string = innerDef?.typeName ?? "";
+      if (innerTypeName !== "ZodOptional" && innerTypeName !== "ZodDefault") required.push(key);
+    }
+    return { ...base, type: "object", properties, ...(required.length > 0 ? { required } : {}), additionalProperties: true };
+  }
+  if (typeName === "ZodString") return { ...base, type: "string" };
+  if (typeName === "ZodNumber") return { ...base, type: "number" };
+  if (typeName === "ZodBoolean") return { ...base, type: "boolean" };
+  if (typeName === "ZodEnum") return { ...base, type: "string", enum: def.values };
+  if (typeName === "ZodLiteral") return { ...base, const: def.value };
+  if (typeName === "ZodUnion") return { ...base, oneOf: (def.options as z.ZodTypeAny[]).map(convertZodType) };
+  if (typeName === "ZodArray") return { ...base, type: "array", items: convertZodType(def.type) };
+  if (typeName === "ZodRecord") return { ...base, type: "object", additionalProperties: convertZodType(def.valueType) };
+  return { ...base, type: "object", additionalProperties: true };
+}
+
+// ---------------------------------------------------------------------------
+// Site adapter scanning
+// ---------------------------------------------------------------------------
+
+const LOCAL_SITES_DIR = join(SHARED_DAEMON_DIR, "sites");
+const COMMUNITY_SITES_DIR = join(SHARED_DAEMON_DIR, "bb-sites");
+
+interface SiteAdapterMeta {
+  name: string;
+  description: string;
+  domain: string;
+  args: Record<string, { required?: boolean; description?: string }>;
+}
+
+export interface PlatformClip {
+  alias: string;           // e.g. "xhs"
+  domain: string;          // first adapter's domain
+  commands: { name: string; description: string; inputSchema: string }[];
+}
+
+function parseSiteMeta(filePath: string, sitesDir: string): SiteAdapterMeta | null {
+  let content: string;
+  try { content = readFileSync(filePath, "utf-8"); } catch { return null; }
+  const defaultName = relative(sitesDir, filePath).replace(/\.js$/, "").replace(/\\/g, "/");
+  const metaMatch = content.match(/\/\*\s*@meta\s*\n([\s\S]*?)\*\//);
+  if (!metaMatch) return { name: defaultName, description: "", domain: "", args: {} };
+  try {
+    const m = JSON.parse(metaMatch[1]);
+    return { name: m.name || defaultName, description: m.description || "", domain: m.domain || "", args: m.args || {} };
+  } catch {
+    return { name: defaultName, description: "", domain: "", args: {} };
+  }
+}
+
+function scanSitesDir(dir: string): SiteAdapterMeta[] {
+  if (!existsSync(dir)) return [];
+  const results: SiteAdapterMeta[] = [];
+  function walk(d: string) {
+    let entries;
+    try { entries = readdirSync(d, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const p = join(d, e.name);
+      if (e.isDirectory() && !e.name.startsWith(".")) walk(p);
+      else if (e.isFile() && e.name.endsWith(".js")) {
+        const m = parseSiteMeta(p, dir);
+        if (m) results.push(m);
+      }
+    }
+  }
+  walk(dir);
+  return results;
+}
+
+/** Convert @meta args to JSON Schema */
+function metaArgsToJsonSchema(args: Record<string, { required?: boolean; description?: string }>): string {
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  for (const [name, def] of Object.entries(args)) {
+    properties[name] = { type: "string", ...(def.description ? { description: def.description } : {}) };
+    if (def.required) required.push(name);
+  }
+  return JSON.stringify({
+    type: "object", properties,
+    ...(required.length > 0 ? { required } : {}),
+    additionalProperties: true,
+  });
+}
+
+/** Scan sites and group by platform. Returns one PlatformClip per platform directory. */
+export function buildPlatformClips(): PlatformClip[] {
+  const community = scanSitesDir(COMMUNITY_SITES_DIR);
+  const local = scanSitesDir(LOCAL_SITES_DIR);
+  // local overrides community by name
+  const byName = new Map<string, SiteAdapterMeta>();
+  for (const s of community) byName.set(s.name, s);
+  for (const s of local) byName.set(s.name, s);
+
+  // Group by platform (first path segment)
+  const groups = new Map<string, SiteAdapterMeta[]>();
+  for (const adapter of byName.values()) {
+    const slash = adapter.name.indexOf("/");
+    if (slash <= 0) continue; // skip adapters without platform prefix
+    const platform = adapter.name.substring(0, slash);
+    const existing = groups.get(platform) || [];
+    existing.push(adapter);
+    groups.set(platform, existing);
+  }
+
+  const clips: PlatformClip[] = [];
+  for (const [platform, adapters] of groups) {
+    const firstDomain = adapters.find((a) => a.domain)?.domain || "";
+    const commands = adapters.map((a) => {
+      const cmdName = a.name.substring(platform.length + 1); // strip "platform/"
+      return {
+        name: cmdName,
+        description: a.description,
+        inputSchema: metaArgsToJsonSchema(a.args),
+      };
+    });
+    clips.push({ alias: platform, domain: firstDomain, commands });
+  }
+  return clips;
+}
+
+// ---------------------------------------------------------------------------
+// Browser command catalog
+// ---------------------------------------------------------------------------
+
+/** All non-site browser commands (open, click, snapshot, tab_list, network, ...). */
+export const BROWSER_COMMANDS = COMMANDS.filter((c) => c.category !== "site");
+
+// ---------------------------------------------------------------------------
+// Command execution
+// ---------------------------------------------------------------------------
+
+export type InputObject = Record<string, unknown>;
+
+/**
+ * Execute a core browser command against the bb-browser daemon.
+ *
+ * Error contract:
+ *   - unknown command / daemon `success:false` -> CommandFailedError
+ *     (application error; safe to surface to the caller).
+ *   - ensureDaemon()/daemonCommand() transport failures propagate as their
+ *     native Error type (internal error; the caller crashes + cold-restarts).
+ */
+export async function executeBrowserCommand(cmdName: string, input: InputObject): Promise<unknown> {
+  const cmd = BROWSER_COMMANDS.find((c) => c.name === cmdName);
+  if (!cmd) throw new CommandFailedError(`Unknown browser command: ${cmdName}`);
+  await ensureDaemon();
+  const { tab, ...rest } = input;
+  const request: Request = {
+    id: generateId(),
+    action: cmd.action as Request["action"],
+    ...rest,
+    ...(tab !== undefined ? { tabId: tab } : {}),
+  } as Request;
+  const response = await daemonCommand(request);
+  if (!response.success) throw new CommandFailedError(response.error || "Command failed");
+  return response.data ?? {};
+}
+
+/** Run a site adapter via the bb-browser CLI. */
+function runSiteCli(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("bb-browser", ["site", ...args], { timeout: 30000, encoding: "utf8" }, (err, stdout, stderr) => {
+      if (err) {
+        const distPath = new URL("../dist/cli.js", import.meta.url).pathname;
+        execFile("node", [distPath, "site", ...args], { timeout: 30000, encoding: "utf8" }, (err2, stdout2, stderr2) => {
+          if (err2) reject(new Error(stdout2.trim() || stderr2 || err2.message));
+          else resolve(stdout2.trim());
+        });
+      } else {
+        resolve(stdout.trim());
+      }
+    });
+  });
+}
+
+/**
+ * Execute a site-adapter command (`<platform>/<command>`) via the CLI.
+ *
+ * Site adapters run as a fresh CLI subprocess, so a failure (not logged in,
+ * page changed, adapter error) is treated as an application error and surfaced
+ * to the caller rather than crashing the shared browser clip.
+ */
+export async function executeSiteCommand(clipName: string, command: string, input: InputObject): Promise<unknown> {
+  // Build CLI args from input
+  const cliArgs: string[] = ["run", `${clipName}/${command}`, "--json"];
+  for (const [key, value] of Object.entries(input)) {
+    if (value !== undefined && value !== null && value !== "") {
+      cliArgs.push(`--${key}`, String(value));
+    }
+  }
+  let raw: string;
+  try {
+    raw = await runSiteCli(cliArgs);
+  } catch (err) {
+    throw new CommandFailedError(err instanceof Error ? err.message : String(err));
+  }
+  try { return JSON.parse(raw); } catch { return { output: raw }; }
+}

--- a/clip.json
+++ b/clip.json
@@ -3,7 +3,7 @@
   "version": "0.10.1",
   "description": "Browser Edge Clip — 浏览器自动化能力",
   "runtime": "bun",
-  "main": "index.ts",
+  "main": "dist/clip.js",
   "author": "yan5xu",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "bin": {
     "bb-browser": "./dist/cli.js",
     "bb-browser-mcp": "./dist/mcp.js",
-    "bb-browser-provider": "./dist/provider.js"
+    "bb-browser-provider": "./dist/provider.js",
+    "bb-browser-clip": "./dist/clip.js"
   },
   "main": "./dist/cli.js",
   "files": [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     daemon: "packages/daemon/src/index.ts",
     mcp: "packages/mcp/src/index.ts",
     provider: "bin/bb-browser-provider.ts",
+    clip: "bin/bb-browser-clip.ts",
   },
   format: ["esm"],
   dts: false,


### PR DESCRIPTION
## What

Adds an IPC v2 NDJSON clip entry so `bb-browser` can run as a Pinix-compatible clip — spawned via `bun run <main> --ipc` and speaking the NDJSON protocol over stdin/stdout. Complements the existing Pinix Hub provider (`bin/bb-browser-provider.ts`), which is left untouched.

## Changes

- `bin/bb-browser-clip.ts` — IPC v2 NDJSON entry (register handshake, read loop, invoke routing, lifecycle).
- `bin/clip-core.ts` — transport-agnostic core extracted for reuse: daemon connection, command execution, site-adapter scanning, zod → JSON Schema, command catalog.
- `tsup.config.ts` / `clip.json` / `package.json` — add the `clip` build entry (`dist/clip.js`) and point `main` at it.

## Behavior

- Sends the `register` manifest first; exposes all browser commands plus site adapters namespaced as `site.<platform>.<command>` (merged into a single clip). `view.*` is skipped (needs the viewer sidecar + TURN).
- Error model: a command that ran-but-failed → `error` message surfaced to the caller; transport/internal failures crash the process so the host cold-restarts it.
- Concurrent invokes don't block the read loop; stdout carries only protocol JSON (all logs go to stderr); stdin close → graceful exit.
